### PR TITLE
feat: file-backed SecretStore for headless/container environments

### DIFF
--- a/internal/auth/secrets_detect.go
+++ b/internal/auth/secrets_detect.go
@@ -1,0 +1,27 @@
+package auth
+
+import "github.com/zalando/go-keyring"
+
+// NewSecretStore returns the best available SecretStore for the current environment.
+// It tries the OS keychain first; if unavailable (containers, CI, headless servers),
+// it falls back to a file-backed store at ~/.meta/secrets.json.
+func NewSecretStore() SecretStore {
+	// Probe keychain availability with a harmless read.
+	_, err := keyring.Get(KeychainService, "__probe__")
+	if err == keyring.ErrNotFound {
+		// Keychain is reachable — the key just doesn't exist.
+		return NewKeychainStore()
+	}
+	if err == nil {
+		// Shouldn't happen for a probe key, but keychain is reachable.
+		return NewKeychainStore()
+	}
+
+	// Any other error means the keychain backend is unavailable.
+	path, pathErr := DefaultFileStorePath()
+	if pathErr != nil {
+		// Can't resolve home dir — fall back to keychain anyway and let it fail later.
+		return NewKeychainStore()
+	}
+	return NewFileStore(path)
+}

--- a/internal/auth/secrets_file.go
+++ b/internal/auth/secrets_file.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// FileStore implements SecretStore using a JSON file on disk.
+// Used as a fallback when the OS keychain (Secret Service / Keychain) is unavailable,
+// e.g. in containers, CI, or headless servers.
+type FileStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewFileStore creates a FileStore that persists secrets to the given path.
+// The parent directory is created if it doesn't exist.
+func NewFileStore(path string) *FileStore {
+	return &FileStore{path: path}
+}
+
+// DefaultFileStorePath returns ~/.meta/secrets.json.
+func DefaultFileStorePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home directory: %w", err)
+	}
+	return filepath.Join(home, ".meta", "secrets.json"), nil
+}
+
+func (f *FileStore) Set(ref string, value string) error {
+	_, _, err := ParseSecretRef(ref)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(value) == "" {
+		return errors.New("secret value cannot be empty")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	data, err := f.load()
+	if err != nil {
+		return err
+	}
+	data[ref] = value
+	return f.save(data)
+}
+
+func (f *FileStore) Get(ref string) (string, error) {
+	_, _, err := ParseSecretRef(ref)
+	if err != nil {
+		return "", err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	data, err := f.load()
+	if err != nil {
+		return "", err
+	}
+	value, ok := data[ref]
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("file secret not found for %q", ref)
+	}
+	return value, nil
+}
+
+func (f *FileStore) Delete(ref string) error {
+	_, _, err := ParseSecretRef(ref)
+	if err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	data, err := f.load()
+	if err != nil {
+		return err
+	}
+	delete(data, ref)
+	return f.save(data)
+}
+
+func (f *FileStore) load() (map[string]string, error) {
+	raw, err := os.ReadFile(f.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("read secrets file: %w", err)
+	}
+	var data map[string]string
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("parse secrets file: %w", err)
+	}
+	return data, nil
+}
+
+func (f *FileStore) save(data map[string]string) error {
+	if err := os.MkdirAll(filepath.Dir(f.path), 0700); err != nil {
+		return fmt.Errorf("create secrets directory: %w", err)
+	}
+	raw, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal secrets: %w", err)
+	}
+	if err := os.WriteFile(f.path, raw, 0600); err != nil {
+		return fmt.Errorf("write secrets file: %w", err)
+	}
+	return nil
+}

--- a/internal/auth/secrets_file_test.go
+++ b/internal/auth/secrets_file_test.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(filepath.Join(dir, "secrets.json"))
+
+	ref, err := SecretRef("prod", SecretToken)
+	if err != nil {
+		t.Fatalf("secret ref: %v", err)
+	}
+	if err := store.Set(ref, "my-token"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, err := store.Get(ref)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != "my-token" {
+		t.Fatalf("got=%q want=%q", got, "my-token")
+	}
+}
+
+func TestFileStoreDelete(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(filepath.Join(dir, "secrets.json"))
+
+	ref, _ := SecretRef("staging", SecretAppSecret)
+	_ = store.Set(ref, "secret-123")
+	if err := store.Delete(ref); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	_, err := store.Get(ref)
+	if err == nil {
+		t.Fatal("expected error after delete")
+	}
+}
+
+func TestFileStoreGetMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(filepath.Join(dir, "secrets.json"))
+
+	ref, _ := SecretRef("prod", SecretToken)
+	_, err := store.Get(ref)
+	if err == nil {
+		t.Fatal("expected error for missing secret")
+	}
+}
+
+func TestFileStoreRejectsEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(filepath.Join(dir, "secrets.json"))
+
+	ref, _ := SecretRef("prod", SecretToken)
+	if err := store.Set(ref, "  "); err == nil {
+		t.Fatal("expected error for empty value")
+	}
+}
+
+func TestFileStoreCreatesDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b", "secrets.json")
+	store := NewFileStore(nested)
+
+	ref, _ := SecretRef("prod", SecretToken)
+	if err := store.Set(ref, "val"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if _, err := os.Stat(nested); err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+}
+
+func TestFileStoreFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "secrets.json")
+	store := NewFileStore(p)
+
+	ref, _ := SecretRef("prod", SecretToken)
+	_ = store.Set(ref, "val")
+
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("permissions=%o want=0600", perm)
+	}
+}
+
+func TestFileStoreMultipleSecrets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(filepath.Join(dir, "secrets.json"))
+
+	ref1, _ := SecretRef("prod", SecretToken)
+	ref2, _ := SecretRef("prod", SecretAppSecret)
+	ref3, _ := SecretRef("staging", SecretToken)
+
+	_ = store.Set(ref1, "token-1")
+	_ = store.Set(ref2, "secret-2")
+	_ = store.Set(ref3, "token-3")
+
+	v1, _ := store.Get(ref1)
+	v2, _ := store.Get(ref2)
+	v3, _ := store.Get(ref3)
+
+	if v1 != "token-1" || v2 != "secret-2" || v3 != "token-3" {
+		t.Fatalf("unexpected values: %q %q %q", v1, v2, v3)
+	}
+}

--- a/internal/cli/cmd/auth.go
+++ b/internal/cli/cmd/auth.go
@@ -708,7 +708,7 @@ func newAuthDebugTokenCommand(runtime Runtime) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				tokenStore := auth.NewKeychainStore()
+				tokenStore := auth.NewSecretStore()
 				token, err = tokenStore.Get(selected.TokenRef)
 				if err != nil {
 					return err
@@ -1053,7 +1053,7 @@ func newAuthService() (authCLIService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return auth.NewService(cfgPath, auth.NewKeychainStore(), nil, auth.DefaultGraphBaseURL), nil
+	return auth.NewService(cfgPath, auth.NewSecretStore(), nil, auth.DefaultGraphBaseURL), nil
 }
 
 func mustMarkFlagRequired(cmd *cobra.Command, name string) {

--- a/internal/cli/cmd/profile.go
+++ b/internal/cli/cmd/profile.go
@@ -42,7 +42,7 @@ func loadProfileCredentials(profile string) (*ProfileCredentials, error) {
 		return nil, fmt.Errorf("auth preflight failed for profile %q: %w", name, err)
 	}
 
-	store := auth.NewKeychainStore()
+	store := auth.NewSecretStore()
 	token, err := store.Get(selected.TokenRef)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func runProfileAuthPreflight(profile string, requiredScopes []string, configPath
 		return errors.New("config path is required")
 	}
 
-	svc := auth.NewService(configPath, auth.NewKeychainStore(), nil, auth.DefaultGraphBaseURL)
+	svc := auth.NewService(configPath, auth.NewSecretStore(), nil, auth.DefaultGraphBaseURL)
 	if _, err := svc.EnsureValid(context.Background(), profile, 72*time.Hour, requiredScopes); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Adds `FileStore` — a file-backed `SecretStore` implementation that persists secrets to `~/.meta/secrets.json` (mode 0600)
- Adds `NewSecretStore()` factory that auto-detects the best backend: tries OS keychain first, falls back to `FileStore` when keychain is unavailable
- Replaces hardcoded `NewKeychainStore()` calls with `NewSecretStore()` in CLI wiring

## Problem

The OS keychain (Linux Secret Service / macOS Keychain) is unavailable in:
- Docker containers
- CI/CD pipelines
- Headless servers (no D-Bus session, no gnome-keyring)

This causes `metacli auth login` tokens to be lost on every container restart, requiring re-authentication each time.

## Solution

The `SecretStore` interface was already cleanly abstracted. This PR adds a second implementation (`FileStore`) and a detection layer that probes keychain availability at startup:

```
NewSecretStore()
  ├── keychain reachable? → KeychainStore (existing behavior, unchanged)
  └── keychain unavailable? → FileStore (~/.meta/secrets.json)
```

No behavior change for desktop users — keychain is still preferred when available.

## Test plan

- [x] 7 new tests for `FileStore` (round-trip, delete, missing key, empty value, directory creation, file permissions, multiple secrets)
- [x] All 36 existing auth tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)