### PR TITLE
Add LinkedIn provider namespace

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -235,6 +235,10 @@ meta li campaign list \
 meta li creative list \
   --profile li-prod \
   --account-urn urn:li:sponsoredAccount:<ID>
+
+meta li account roles \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID>
 ```
 
 Reporting:
@@ -248,9 +252,24 @@ meta li insights run \
   --account-urns urn:li:sponsoredAccount:<ID> \
   --since 2026-03-01 \
   --until 2026-03-07 \
+  --level ACCOUNT \
+  --metric-pack basic
+
+meta li insights run \
+  --profile li-prod \
+  --account-urns urn:li:sponsoredAccount:<ID> \
+  --since 2026-03-01 \
+  --until 2026-03-07 \
   --level CAMPAIGN \
-  --metric-pack delivery
+  --metric-pack delivery \
+  --page-size 100 \
+  --page-token 0
 ```
+
+Notes:
+
+- `metric-pack basic` omits `fields` and relies on LinkedIn's default analytics response (`impressions` and `clicks`).
+- `li insights run` and `li account roles` treat `--page-token` as a numeric offset token, not a cursor.
 
 Core ad ops:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -67,6 +67,20 @@ meta auth validate --profile prod
 
 Browser-based OAuth setup is the primary path.
 
+Where `CLIENT_ID` and `CLIENT_SECRET` come from:
+- Go to the LinkedIn Developer Portal: `https://www.linkedin.com/developers/apps`
+- Create a new app, or open an existing app under `My Apps`
+- If you create a new app, LinkedIn requires the usual app metadata first, including an app name, your organization's LinkedIn Page, a privacy policy URL, and an app logo
+- Open the app's `Auth` tab
+- Copy the `Client ID` and reveal/copy the `Client Secret` from the application credentials area
+- Add your OAuth callback URL under the same `Auth` tab before running `meta li auth setup`
+- If you do not see the marketing scopes you need, request the appropriate product access under the app's `Products` tab first; LinkedIn only exposes scopes that your app has been approved for
+- For Marketing API usage, also configure the allowed ad accounts from the app's `Products` tab when LinkedIn requires it for your tier
+
+Recommended minimum check before using the CLI:
+- confirm the app has the approved scopes you plan to request, such as `r_ads`, `rw_ads`, `r_ads_reporting`, or `r_marketing_leadgen_automation`
+- confirm the authenticated LinkedIn member has the required ad account or organization roles, otherwise auth may succeed but resource commands will still fail closed
+
 ```bash
 meta li auth setup \
   --profile li-prod \

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,287 @@
+# Meta Marketing CLI Usage
+
+Operator-focused guide for the `meta` binary. The CLI keeps a stable machine-readable envelope, but the command surfaces are provider-specific:
+- `meta` = existing Meta / Graph / Instagram / Messenger / WhatsApp / Threads / CAPI / ops workflows.
+- `meta li` = LinkedIn Marketing workflows.
+
+Use `--help` on any command for the full flag set. Prefer explicit `--profile` values and `--output json` unless you are scripting around `jsonl`, `table`, or `csv`.
+
+## Profile Model
+
+Profiles live in `~/.meta/config.yaml` with `schema_version: 2`.
+
+- Existing Meta profiles remain valid with an implicit `provider: meta`.
+- LinkedIn profiles must set `provider: linkedin`.
+- Meta profiles use `graph_version`.
+- LinkedIn profiles use `linkedin_version` and never route through Graph path versioning.
+
+Minimal shape:
+
+```yaml
+schema_version: 2
+default_profile: prod
+profiles:
+  prod:
+    domain: marketing
+    graph_version: v25.0
+    token_type: system_user
+    app_id: <APP_ID>
+    app_secret_ref: keychain://...
+    token_ref: keychain://...
+    auth_provider: system_user
+    auth_mode: both
+    scopes: [<meta scopes>]
+    issued_at: 2026-03-23T00:00:00Z
+    expires_at: 2026-03-24T00:00:00Z
+    last_validated_at: 2026-03-23T00:00:00Z
+  li-prod:
+    provider: linkedin
+    domain: marketing
+    linkedin_version: "202601"
+    client_id: <CLIENT_ID>
+    client_secret_ref: keychain://...
+    refresh_token_ref: keychain://...
+    token_ref: keychain://...
+    scopes: [<approved linkedin scopes>]
+    issued_at: 2026-03-23T00:00:00Z
+    expires_at: 2026-03-24T00:00:00Z
+    last_validated_at: 2026-03-23T00:00:00Z
+```
+
+## Quick Start
+
+### Meta
+
+```bash
+meta auth setup \
+  --profile prod \
+  --app-id <APP_ID> \
+  --app-secret <APP_SECRET> \
+  --mode both \
+  --scope-pack solo_smb
+
+meta auth validate --profile prod
+```
+
+### LinkedIn
+
+Browser-based OAuth setup is the primary path.
+
+```bash
+meta li auth setup \
+  --profile li-prod \
+  --client-id <CLIENT_ID> \
+  --client-secret <CLIENT_SECRET> \
+  --linkedin-version 202601 \
+  --scopes <approved,comma-separated,LinkedIn,scopes> \
+  --listen-addr 127.0.0.1:53682 \
+  --open-browser
+
+meta li auth validate --profile li-prod
+meta li auth scopes --profile li-prod
+meta li auth whoami --profile li-prod
+```
+
+## Existing Meta Surfaces
+
+Top-level families on the existing Meta side:
+- `auth`: `setup`, `login`, `login-manual`, `discover`, `validate`, `rotate`, `debug-token`, `list`
+- `api`: `get`, `post`, `delete`, `batch`
+- `campaign`, `adset`, `ad`, `creative`, `audience`, `catalog`
+- `insights`: `accounts list`, `run`, `action-types`
+- `ig`: `caption validate`, `media upload/status`, `publish feed|reel|story`, `publish schedule list|cancel|retry|run`, `insights ...`
+- `msgr`: `health`, `auto-reply`, `conversations`
+- `wa`: `health`, `capability`
+- `threads`: `health`, `capability`
+- `capi`: `health`, `capability`
+- `ops`: `init`, `run`
+- `doctor`: `tracer`
+- `schema`: `list`, `sync`
+- `lint`: `request`
+- `changelog`: `check`
+- `enterprise`: context, authorization, approvals, execution governance
+- `smoke`: deterministic capability-aware smoke workflows
+
+Common examples:
+
+```bash
+meta --profile prod api get act_<AD_ACCOUNT_ID>/campaigns \
+  --fields id,name,status \
+  --follow-next
+
+meta --profile prod campaign create \
+  --account-id <AD_ACCOUNT_ID> \
+  --params "name=Launch Campaign,objective=OUTCOME_SALES,status=PAUSED"
+
+meta --profile prod insights accounts list --active-only --output table
+
+meta schema sync
+
+meta lint request \
+  --file ./requests/campaign-create.json \
+  --strict
+
+meta --profile prod ig publish feed \
+  --media-url https://cdn.example.com/launch.jpg \
+  --caption "Shipped from CLI" \
+  --idempotency-key launch-feed-001
+
+meta smoke run
+
+meta msgr health
+```
+
+## LinkedIn Surfaces
+
+Top-level namespaces:
+- `auth`
+- `api`
+- `account`
+- `organization`
+- `campaign-group`
+- `campaign`
+- `creative`
+- `insights`
+- `targeting`
+- `lead-form`
+- `lead`
+
+Provider caveats:
+- `li account list` is the discovery entrypoint for ad accounts.
+- LinkedIn raw API and reporting use `--version YYYYMM` or the profile's `linkedin_version`.
+- `li targeting` is policy-sensitive. Use lawful targeting only and expect validation failures to block unsafe combinations.
+- `li lead sync` is stateful and idempotent. Use `--state-file` and `--reset` intentionally.
+
+Auth:
+
+```bash
+meta li auth setup \
+  --profile li-prod \
+  --client-id <CLIENT_ID> \
+  --client-secret <CLIENT_SECRET> \
+  --linkedin-version 202601 \
+  --scopes <approved,comma-separated,LinkedIn,scopes>
+
+meta li auth validate --profile li-prod
+meta li auth scopes --profile li-prod
+meta li auth whoami --profile li-prod
+```
+
+Raw API:
+
+```bash
+meta li api get /rest/adAccounts \
+  --profile li-prod \
+  --version 202601 \
+  --follow-next \
+  --page-size 100
+
+meta li api post /rest/adCampaignGroups \
+  --profile li-prod \
+  --version 202601 \
+  --json '{"name":"CLI test group"}'
+
+meta li api delete /rest/<resource>/<id> \
+  --profile li-prod \
+  --version 202601
+```
+
+Discovery:
+
+```bash
+meta li account list \
+  --profile li-prod \
+  --search active \
+  --page-size 100
+
+meta li organization list \
+  --profile li-prod \
+  --search "Acme"
+
+meta li campaign-group list \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID>
+
+meta li campaign list \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID>
+
+meta li creative list \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID>
+```
+
+Reporting:
+
+```bash
+meta --profile li-prod li insights metrics list
+meta --profile li-prod li insights pivots list
+
+meta li insights run \
+  --profile li-prod \
+  --account-urns urn:li:sponsoredAccount:<ID> \
+  --since 2026-03-01 \
+  --until 2026-03-07 \
+  --level CAMPAIGN \
+  --metric-pack delivery
+```
+
+Core ad ops:
+
+```bash
+meta li campaign-group pause \
+  --profile li-prod \
+  --version 202601 \
+  --confirm \
+  <CAMPAIGN_GROUP_ID>
+
+meta li campaign create \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID> \
+  --confirm-budget-change \
+  --confirm-schedule-change \
+  --json '{"name":"CLI Campaign"}'
+
+meta li creative create \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID> \
+  --json '{"name":"CLI Creative"}'
+```
+
+Targeting:
+
+```bash
+meta --profile li-prod li targeting facets --version 202601
+meta --profile li-prod li targeting search --version 202601
+meta li targeting validate \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID> \
+  --facet-urns <URN_1,URN_2>
+```
+
+Lead intake:
+
+```bash
+meta li lead-form list \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID>
+
+meta li lead list \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID>
+
+meta li lead sync \
+  --profile li-prod \
+  --account-urn urn:li:sponsoredAccount:<ID> \
+  --state-file ~/.meta/li-leads.state.json \
+  --page-size 100
+
+meta li lead webhook list --profile li-prod
+```
+
+## Practical Notes
+
+- Use `meta doctor tracer` when you want a quick integrity check on command plumbing.
+- Use `meta auth validate` or `meta li auth validate` before running a batch of writes.
+- Keep output automation-friendly. `json` and `jsonl` are the safest defaults for scripts.
+- For LinkedIn, prefer raw `li api` calls only when a higher-level command does not yet exist. For routine ops, use the typed resource commands first.

--- a/USAGE.md
+++ b/USAGE.md
@@ -86,6 +86,11 @@ Recommended minimum check before using the CLI:
 - confirm the app has the approved scopes you plan to request, such as `r_ads`, `rw_ads`, `r_ads_reporting`, or `r_marketing_leadgen_automation`
 - confirm the authenticated LinkedIn member has the required ad account or organization roles, otherwise auth may succeed but resource commands will still fail closed
 
+Best-effort identity lookup:
+- `meta li auth setup` and `meta li auth validate` treat LinkedIn member lookup as optional
+- for Ads-only apps, `whoami` may be `null` with a warning if the app does not have an identity scope such as `r_liteprofile`
+- Ads commands such as `meta li account list` can still work even when member profile lookup is unavailable
+
 ```bash
 meta li auth setup \
   --profile li-prod \

--- a/USAGE.md
+++ b/USAGE.md
@@ -67,6 +67,11 @@ meta auth validate --profile prod
 
 Browser-based OAuth setup is the primary path.
 
+Auth flow selection:
+- `meta li auth setup` now defaults to the standard LinkedIn 3-legged OAuth endpoint: `https://www.linkedin.com/oauth/v2/authorization`
+- Use `--auth-flow native-pkce` only if LinkedIn has explicitly enabled PKCE-native auth for your app; that path uses `https://www.linkedin.com/oauth/native-pkce/authorization`
+- For most server-side or CLI operator workflows, the standard flow is the correct default
+
 Where `CLIENT_ID` and `CLIENT_SECRET` come from:
 - Go to the LinkedIn Developer Portal: `https://www.linkedin.com/developers/apps`
 - Create a new app, or open an existing app under `My Apps`
@@ -86,6 +91,7 @@ meta li auth setup \
   --profile li-prod \
   --client-id <CLIENT_ID> \
   --client-secret <CLIENT_SECRET> \
+  --auth-flow standard \
   --linkedin-version 202601 \
   --scopes <approved,comma-separated,LinkedIn,scopes> \
   --listen-addr 127.0.0.1:53682 \
@@ -173,6 +179,7 @@ meta li auth setup \
   --profile li-prod \
   --client-id <CLIENT_ID> \
   --client-secret <CLIENT_SECRET> \
+  --auth-flow standard \
   --linkedin-version 202601 \
   --scopes <approved,comma-separated,LinkedIn,scopes>
 

--- a/internal/auth/secrets.go
+++ b/internal/auth/secrets.go
@@ -9,9 +9,11 @@ import (
 )
 
 const (
-	KeychainService = "meta-marketing-cli"
-	SecretToken     = "token"
-	SecretAppSecret = "app_secret"
+	KeychainService    = "meta-marketing-cli"
+	SecretToken        = "token"
+	SecretAppSecret    = "app_secret"
+	SecretClientSecret = "client_secret"
+	SecretRefreshToken = "refresh_token"
 )
 
 type SecretStore interface {
@@ -59,7 +61,7 @@ func SecretRef(profile string, kind string) (string, error) {
 	}
 
 	switch kind {
-	case SecretToken, SecretAppSecret:
+	case SecretToken, SecretAppSecret, SecretClientSecret, SecretRefreshToken:
 	default:
 		return "", fmt.Errorf("unsupported secret kind %q", kind)
 	}
@@ -84,7 +86,7 @@ func ParseSecretRef(ref string) (string, string, error) {
 	if profile == "" || kind == "" {
 		return "", "", fmt.Errorf("invalid secret ref %q: empty profile or kind", ref)
 	}
-	if kind != SecretToken && kind != SecretAppSecret {
+	if kind != SecretToken && kind != SecretAppSecret && kind != SecretClientSecret && kind != SecretRefreshToken {
 		return "", "", fmt.Errorf("invalid secret ref %q: unknown kind %q", ref, kind)
 	}
 	return profile, kind, nil

--- a/internal/auth/secrets_test.go
+++ b/internal/auth/secrets_test.go
@@ -44,6 +44,24 @@ func TestSecretRefDeterministic(t *testing.T) {
 	}
 }
 
+func TestSecretRefSupportsLinkedInSecretKinds(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []string{SecretClientSecret, SecretRefreshToken} {
+		ref, err := SecretRef("li-prod", kind)
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", kind, err)
+		}
+		_, parsedKind, err := ParseSecretRef(ref)
+		if err != nil {
+			t.Fatalf("parse ref %s: %v", ref, err)
+		}
+		if parsedKind != kind {
+			t.Fatalf("unexpected kind: got=%s want=%s", parsedKind, kind)
+		}
+	}
+}
+
 func TestKeychainStoreRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/cmd/doctor_checks.go
+++ b/internal/cli/cmd/doctor_checks.go
@@ -161,15 +161,29 @@ func runDoctorChecks(cmd *cobra.Command, runtime Runtime, deps *doctorDeps) erro
 	for _, name := range profiles {
 		profile := cfg.Profiles[name]
 		tokenErr := checkSecretAccess(secretStore, profile.TokenRef)
-		appSecretErr := checkSecretAccess(secretStore, profile.AppSecretRef)
-
-		if tokenErr != nil || appSecretErr != nil {
-			msg := "secret store access failed:"
-			if tokenErr != nil {
-				msg += fmt.Sprintf(" token_ref: %v", tokenErr)
+		provider := config.ResolveProvider(profile.Provider)
+		secretErrors := make([]string, 0, 3)
+		if tokenErr != nil {
+			secretErrors = append(secretErrors, fmt.Sprintf("token_ref: %v", tokenErr))
+		}
+		switch provider {
+		case config.ProviderMeta:
+			if err := checkSecretAccess(secretStore, profile.AppSecretRef); err != nil {
+				secretErrors = append(secretErrors, fmt.Sprintf("app_secret_ref: %v", err))
 			}
-			if appSecretErr != nil {
-				msg += fmt.Sprintf(" app_secret_ref: %v", appSecretErr)
+		case config.ProviderLinkedIn:
+			if err := checkSecretAccess(secretStore, profile.ClientSecretRef); err != nil {
+				secretErrors = append(secretErrors, fmt.Sprintf("client_secret_ref: %v", err))
+			}
+			if err := checkSecretAccess(secretStore, profile.RefreshTokenRef); err != nil {
+				secretErrors = append(secretErrors, fmt.Sprintf("refresh_token_ref: %v", err))
+			}
+		}
+
+		if len(secretErrors) > 0 {
+			msg := "secret store access failed:"
+			for _, detail := range secretErrors {
+				msg += " " + detail
 			}
 			checks = append(checks, doctorCheck{
 				Name:    "secret_store",
@@ -191,6 +205,18 @@ func runDoctorChecks(cmd *cobra.Command, runtime Runtime, deps *doctorDeps) erro
 	svc := auth.NewService(configPath, secretStore, httpClient, graphBaseURL)
 	ctx := context.Background()
 	for _, name := range profiles {
+		profile := cfg.Profiles[name]
+		if config.ResolveProvider(profile.Provider) == config.ProviderLinkedIn {
+			status, message := doctorLinkedInTokenStatus(profile)
+			checks = append(checks, doctorCheck{
+				Name:    "token_validity",
+				Status:  status,
+				Message: message,
+				Profile: name,
+			})
+			continue
+		}
+
 		_, err := svc.ValidateProfile(ctx, name)
 		if err != nil {
 			checks = append(checks, doctorCheck{
@@ -199,14 +225,14 @@ func runDoctorChecks(cmd *cobra.Command, runtime Runtime, deps *doctorDeps) erro
 				Message: fmt.Sprintf("token validation failed: %v", err),
 				Profile: name,
 			})
-		} else {
-			checks = append(checks, doctorCheck{
-				Name:    "token_validity",
-				Status:  checkPass,
-				Message: "token valid",
-				Profile: name,
-			})
+			continue
 		}
+		checks = append(checks, doctorCheck{
+			Name:    "token_validity",
+			Status:  checkPass,
+			Message: "token valid",
+			Profile: name,
+		})
 	}
 
 	return writeSuccess(cmd, runtime, commandName, buildResult(checks), nil, nil)
@@ -233,6 +259,22 @@ func checkSecretAccess(store auth.SecretStore, ref string) error {
 	}
 	_, err := store.Get(ref)
 	return err
+}
+
+func doctorLinkedInTokenStatus(profile config.Profile) (checkStatus, string) {
+	expiresAt, err := time.Parse(time.RFC3339, profile.ExpiresAt)
+	if err != nil {
+		return checkFail, fmt.Sprintf("linkedin token expiry is invalid: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if !expiresAt.After(now) {
+		return checkFail, fmt.Sprintf("linkedin access token expired at %s", profile.ExpiresAt)
+	}
+	if expiresAt.Before(now.Add(24 * time.Hour)) {
+		return checkWarn, fmt.Sprintf("linkedin access token expires soon at %s", profile.ExpiresAt)
+	}
+	return checkPass, "linkedin token window looks healthy"
 }
 
 func buildResult(checks []doctorCheck) doctorCheckResult {

--- a/internal/cli/cmd/li.go
+++ b/internal/cli/cmd/li.go
@@ -1,0 +1,136 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func NewLICommand(runtime Runtime) *cobra.Command {
+	liCmd := &cobra.Command{
+		Use:   "li",
+		Short: "LinkedIn Marketing commands",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return requireSubcommand(cmd, "li")
+		},
+	}
+
+	liCmd.AddCommand(newLIAuthCommand(runtime))
+	liCmd.AddCommand(newLIApiCommand(runtime))
+	liCmd.AddCommand(newLIAccountCommand(runtime))
+	liCmd.AddCommand(newLIOrganizationCommand(runtime))
+	liCmd.AddCommand(newLICampaignGroupCommand(runtime))
+	liCmd.AddCommand(newLICampaignCommand(runtime))
+	liCmd.AddCommand(newLICreativeCommand(runtime))
+	liCmd.AddCommand(newLIInsightsCommand(runtime))
+	liCmd.AddCommand(newLITargetingCommand(runtime))
+	liCmd.AddCommand(newLILeadFormCommand(runtime))
+	liCmd.AddCommand(newLILeadCommand(runtime))
+	return liCmd
+}
+
+func newLIAuthCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("auth", "LinkedIn auth commands")
+	cmd.AddCommand(newLIAuthSetupCommand(runtime))
+	cmd.AddCommand(newLIAuthValidateCommand(runtime))
+	cmd.AddCommand(newLIAuthScopesCommand(runtime))
+	cmd.AddCommand(newLIAuthWhoAmICommand(runtime))
+	return cmd
+}
+
+func newLIApiCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("api", "Raw LinkedIn API commands")
+	cmd.AddCommand(newLIApiGetCommand(runtime))
+	cmd.AddCommand(newLIApiPostCommand(runtime))
+	cmd.AddCommand(newLIApiDeleteCommand(runtime))
+	return cmd
+}
+
+func newLIAccountCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("account", "LinkedIn ad account commands")
+	cmd.AddCommand(newLIAccountListCommand(runtime))
+	cmd.AddCommand(newLIAccountRolesCommand(runtime))
+	return cmd
+}
+
+func newLIOrganizationCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("organization", "LinkedIn organization commands")
+	cmd.AddCommand(newLIOrganizationListCommand(runtime))
+	cmd.AddCommand(newLIOrganizationGetCommand(runtime))
+	cmd.AddCommand(newLIOrganizationRolesCommand(runtime))
+	return cmd
+}
+
+func newLICampaignGroupCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("campaign-group", "LinkedIn campaign group commands")
+	cmd.AddCommand(newLICampaignGroupListCommand(runtime))
+	cmd.AddCommand(newLICampaignGroupGetCommand(runtime))
+	cmd.AddCommand(newLICampaignGroupUpdateCommand(runtime))
+	cmd.AddCommand(newLICampaignGroupPauseCommand(runtime))
+	cmd.AddCommand(newLICampaignGroupResumeCommand(runtime))
+	return cmd
+}
+
+func newLICampaignCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("campaign", "LinkedIn campaign commands")
+	cmd.AddCommand(newLICampaignListCommand(runtime))
+	cmd.AddCommand(newLICampaignGetCommand(runtime))
+	cmd.AddCommand(newLICampaignCreateCommand(runtime))
+	cmd.AddCommand(newLICampaignUpdateCommand(runtime))
+	cmd.AddCommand(newLICampaignPauseCommand(runtime))
+	cmd.AddCommand(newLICampaignResumeCommand(runtime))
+	return cmd
+}
+
+func newLICreativeCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("creative", "LinkedIn creative commands")
+	cmd.AddCommand(newLICreativeListCommand(runtime))
+	cmd.AddCommand(newLICreativeGetCommand(runtime))
+	cmd.AddCommand(newLICreativeCreateCommand(runtime))
+	cmd.AddCommand(newLICreativeUpdateCommand(runtime))
+	cmd.AddCommand(newLICreativeArchiveCommand(runtime))
+	return cmd
+}
+
+func newLIInsightsCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("insights", "LinkedIn reporting commands")
+	cmd.AddCommand(newLIInsightsRunCommand(runtime))
+	cmd.AddCommand(newLIInsightsMetricsListCommand(runtime))
+	cmd.AddCommand(newLIInsightsPivotsListCommand(runtime))
+	cmd.AddCommand(newLIInsightsDemographicRunCommand(runtime))
+	return cmd
+}
+
+func newLITargetingCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("targeting", "LinkedIn targeting commands")
+	cmd.Long = "LinkedIn targeting commands. Respect LinkedIn anti-discrimination requirements and avoid building audience criteria around protected characteristics."
+	cmd.AddCommand(newLITargetingFacetsCommand(runtime))
+	cmd.AddCommand(newLITargetingEntitiesCommand(runtime))
+	cmd.AddCommand(newLITargetingSearchCommand(runtime))
+	cmd.AddCommand(newLITargetingSimilarCommand(runtime))
+	cmd.AddCommand(newLITargetingValidateCommand(runtime))
+	return cmd
+}
+
+func newLILeadFormCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("lead-form", "LinkedIn lead form commands")
+	cmd.AddCommand(newLILeadFormListCommand(runtime))
+	cmd.AddCommand(newLILeadFormGetCommand(runtime))
+	cmd.AddCommand(newLILeadFormCreateCommand(runtime))
+	return cmd
+}
+
+func newLILeadCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("lead", "LinkedIn lead commands")
+	cmd.AddCommand(newLILeadListCommand(runtime))
+	cmd.AddCommand(newLILeadGetCommand(runtime))
+	cmd.AddCommand(newLILeadSyncCommand(runtime))
+	cmd.AddCommand(newLILeadWebhookCommand(runtime))
+	return cmd
+}
+
+func newLISubcommandGroup(use string, short string) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return requireSubcommand(cmd, "li "+use)
+		},
+	}
+}

--- a/internal/cli/cmd/li_api.go
+++ b/internal/cli/cmd/li_api.go
@@ -1,0 +1,234 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/bilalbayram/metacli/internal/linkedin"
+	"github.com/spf13/cobra"
+)
+
+func newLIApiGetCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile      string
+		version      string
+		paramsRaw    string
+		fields       string
+		restliMethod string
+		followNext   bool
+		limit        int
+		pageSize     int
+		stream       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get <path>",
+		Short: "Run a raw LinkedIn GET request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api get", err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api get", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			query, err := parseKeyValueList(paramsRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api get", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			if strings.TrimSpace(fields) != "" {
+				query["fields"] = fields
+			}
+			if pageSize > 0 {
+				query[linkedin.DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+			}
+
+			request := linkedin.Request{
+				Method:              http.MethodGet,
+				Path:                normalizeLinkedInAPIPath(args[0]),
+				Version:             resolvedVersion,
+				Query:               query,
+				Headers:             linkedInRestliHeaders(restliMethod),
+				AllowQueryTunneling: true,
+			}
+
+			if followNext || stream {
+				rows := make([]map[string]any, 0)
+				paging, err := client.FetchCollection(cmd.Context(), request, linkedin.PaginationOptions{
+					FollowNext: followNext || stream,
+					Limit:      limit,
+					PageSize:   pageSize,
+				}, func(row map[string]any) error {
+					if stream {
+						line, marshalErr := json.Marshal(row)
+						if marshalErr != nil {
+							return marshalErr
+						}
+						_, writeErr := fmt.Fprintln(cmd.OutOrStdout(), string(line))
+						return writeErr
+					}
+					rows = append(rows, row)
+					return nil
+				})
+				if err != nil {
+					return writeCommandErrorWithProvider(cmd, runtime, "meta li api get", err, linkedInEnvelopeProvider(resolvedVersion))
+				}
+				if stream {
+					return nil
+				}
+				return writeSuccessWithProvider(cmd, runtime, "meta li api get", rows, paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+			}
+
+			resp, err := client.Do(cmd.Context(), request)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api get", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li api get", resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&paramsRaw, "params", "", "Comma-separated query params (k=v,k2=v2)")
+	cmd.Flags().StringVar(&fields, "fields", "", "Comma-separated fields selector")
+	cmd.Flags().StringVar(&restliMethod, "restli-method", "", "Optional X-RestLi-Method header value")
+	cmd.Flags().BoolVar(&followNext, "follow-next", false, "Follow cursor pagination")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of records to return")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size for paginated queries")
+	cmd.Flags().BoolVar(&stream, "stream", false, "Stream collection elements as JSONL")
+	return cmd
+}
+
+func newLIApiPostCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile      string
+		version      string
+		paramsRaw    string
+		jsonRaw      string
+		restliMethod string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "post <path>",
+		Short: "Run a raw LinkedIn POST request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api post", err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api post", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			query, err := parseKeyValueList(paramsRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api post", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			body, err := parseRawJSONBody(jsonRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api post", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:   http.MethodPost,
+				Path:     normalizeLinkedInAPIPath(args[0]),
+				Version:  resolvedVersion,
+				Query:    query,
+				Headers:  linkedInRestliHeaders(restliMethod),
+				JSONBody: body,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api post", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li api post", resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&paramsRaw, "params", "", "Comma-separated query params (k=v,k2=v2)")
+	cmd.Flags().StringVar(&jsonRaw, "json", "", "Inline JSON payload")
+	cmd.Flags().StringVar(&restliMethod, "restli-method", "", "Optional X-RestLi-Method header value")
+	return cmd
+}
+
+func newLIApiDeleteCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile      string
+		version      string
+		paramsRaw    string
+		restliMethod string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <path>",
+		Short: "Run a raw LinkedIn DELETE request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api delete", err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api delete", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			query, err := parseKeyValueList(paramsRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api delete", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:              http.MethodDelete,
+				Path:                normalizeLinkedInAPIPath(args[0]),
+				Version:             resolvedVersion,
+				Query:               query,
+				Headers:             linkedInRestliHeaders(restliMethod),
+				AllowQueryTunneling: true,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li api delete", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li api delete", resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&paramsRaw, "params", "", "Comma-separated query params (k=v,k2=v2)")
+	cmd.Flags().StringVar(&restliMethod, "restli-method", "", "Optional X-RestLi-Method header value")
+	return cmd
+}
+
+func normalizeLinkedInAPIPath(raw string) string {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "/rest"
+	}
+	if strings.HasPrefix(path, "/rest/") || strings.HasPrefix(path, "/v2/") {
+		return path
+	}
+	return "/rest/" + strings.TrimPrefix(path, "/")
+}
+
+func linkedInRestliHeaders(restliMethod string) map[string]string {
+	method := strings.TrimSpace(restliMethod)
+	if method == "" {
+		return nil
+	}
+	return map[string]string{"X-RestLi-Method": method}
+}
+
+func parseRawJSONBody(raw string) (any, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, fmt.Errorf("decode --json payload: %w", err)
+	}
+	return decoded, nil
+}

--- a/internal/cli/cmd/li_auth.go
+++ b/internal/cli/cmd/li_auth.go
@@ -1,0 +1,278 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bilalbayram/metacli/internal/auth"
+	"github.com/bilalbayram/metacli/internal/config"
+	"github.com/bilalbayram/metacli/internal/linkedin"
+	"github.com/spf13/cobra"
+)
+
+func newLIAuthSetupCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile      string
+		clientID     string
+		clientSecret string
+		version      string
+		scopesRaw    string
+		listenAddr   string
+		redirectURI  string
+		timeout      time.Duration
+		openBrowser  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Run LinkedIn browser-based OAuth setup",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			profileName, err := resolveLIProfileName(runtime, profile)
+			if err != nil {
+				return writeCommandError(cmd, runtime, "meta li auth setup", err)
+			}
+			resolvedRedirectURI := strings.TrimSpace(redirectURI)
+			if resolvedRedirectURI == "" {
+				resolvedRedirectURI = fmt.Sprintf("http://%s%s", strings.TrimSpace(listenAddr), defaultAuthCallbackPath)
+			}
+
+			resolvedVersion, err := bootstrapLinkedInProfile(profileName, clientID, clientSecret, version, csvToSlice(scopesRaw))
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(version))
+			}
+
+			svc, err := newLinkedInAuthService()
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := svc.Setup(cmd.Context(), profileName, linkedinSetupInput(profileName, resolvedRedirectURI, csvToSlice(scopesRaw), timeout, openBrowser))
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li auth setup", result, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "LinkedIn application client id")
+	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "LinkedIn application client secret")
+	cmd.Flags().StringVar(&version, "linkedin-version", "", "LinkedIn API version header (YYYYMM)")
+	cmd.Flags().StringVar(&scopesRaw, "scopes", "", "Comma-separated OAuth scopes")
+	cmd.Flags().StringVar(&listenAddr, "listen-addr", defaultAuthListenAddr, "Local callback listener address")
+	cmd.Flags().StringVar(&redirectURI, "redirect-uri", "", "OAuth redirect URI; defaults to http://<listen-addr>/oauth/callback")
+	cmd.Flags().DurationVar(&timeout, "timeout", defaultAuthTimeout, "OAuth callback timeout")
+	cmd.Flags().BoolVar(&openBrowser, "open-browser", true, "Open the authorization URL in the default browser")
+	return cmd
+}
+
+func newLIAuthValidateCommand(runtime Runtime) *cobra.Command {
+	var profile string
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate and refresh the current LinkedIn token if needed",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			profileName, err := resolveLIProfileName(runtime, profile)
+			if err != nil {
+				return writeCommandError(cmd, runtime, "meta li auth validate", err)
+			}
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profileName, "")
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth validate", err, linkedInEnvelopeProvider(""))
+			}
+			svc, err := newLinkedInAuthService()
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth validate", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := svc.Validate(cmd.Context(), profileName)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth validate", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result.Token.AccessToken = creds.Token
+			result.Token.RefreshToken = creds.RefreshToken
+			return writeSuccessWithProvider(cmd, runtime, "meta li auth validate", result, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	return cmd
+}
+
+func newLIAuthScopesCommand(runtime Runtime) *cobra.Command {
+	var profile string
+
+	cmd := &cobra.Command{
+		Use:   "scopes",
+		Short: "List LinkedIn scopes granted to the active profile",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			profileName, err := resolveLIProfileName(runtime, profile)
+			if err != nil {
+				return writeCommandError(cmd, runtime, "meta li auth scopes", err)
+			}
+			_, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profileName, "")
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth scopes", err, linkedInEnvelopeProvider(""))
+			}
+			svc, err := newLinkedInAuthService()
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth scopes", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			scopes, err := svc.Scopes(cmd.Context(), profileName)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth scopes", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li auth scopes", map[string]any{
+				"profile": profileName,
+				"scopes":  scopes,
+			}, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	return cmd
+}
+
+func newLIAuthWhoAmICommand(runtime Runtime) *cobra.Command {
+	var profile string
+
+	cmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Resolve the member associated with the active LinkedIn profile",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			profileName, err := resolveLIProfileName(runtime, profile)
+			if err != nil {
+				return writeCommandError(cmd, runtime, "meta li auth whoami", err)
+			}
+			_, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profileName, "")
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth whoami", err, linkedInEnvelopeProvider(""))
+			}
+			svc, err := newLinkedInAuthService()
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth whoami", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := svc.WhoAmI(cmd.Context(), profileName)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth whoami", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li auth whoami", result, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	return cmd
+}
+
+func resolveLIProfileName(runtime Runtime, profile string) (string, error) {
+	resolved := strings.TrimSpace(profile)
+	if resolved == "" {
+		resolved = runtime.ProfileName()
+	}
+	if resolved == "" {
+		return "", errors.New("profile is required (--profile or global --profile)")
+	}
+	return resolved, nil
+}
+
+func bootstrapLinkedInProfile(profileName string, clientID string, clientSecret string, version string, scopes []string) (string, error) {
+	configPath, err := config.DefaultPath()
+	if err != nil {
+		return "", err
+	}
+	cfg, err := config.LoadOrCreate(configPath)
+	if err != nil {
+		return "", err
+	}
+	store := auth.NewSecretStore()
+
+	existing := config.Profile{}
+	if _, profile, resolveErr := cfg.ResolveProfile(profileName); resolveErr == nil {
+		existing = profile
+		if provider := config.ResolveProvider(existing.Provider); provider != config.ProviderLinkedIn {
+			return "", fmt.Errorf("profile %q uses provider %q, expected %q", profileName, provider, config.ProviderLinkedIn)
+		}
+	}
+
+	resolvedClientID := strings.TrimSpace(clientID)
+	if resolvedClientID == "" {
+		resolvedClientID = strings.TrimSpace(existing.ClientID)
+	}
+	if resolvedClientID == "" {
+		return "", errors.New("client id is required")
+	}
+	resolvedVersion := strings.TrimSpace(version)
+	if resolvedVersion == "" {
+		resolvedVersion = strings.TrimSpace(existing.LinkedInVersion)
+	}
+	if resolvedVersion == "" {
+		resolvedVersion = config.DefaultLinkedInVersion
+	}
+	resolvedScopes := scopes
+	if len(resolvedScopes) == 0 {
+		resolvedScopes = append([]string(nil), existing.Scopes...)
+	}
+	if len(resolvedScopes) == 0 {
+		return "", errors.New("at least one LinkedIn scope is required")
+	}
+
+	tokenRef, err := auth.SecretRef(profileName, auth.SecretToken)
+	if err != nil {
+		return "", err
+	}
+	clientSecretRef, err := auth.SecretRef(profileName, auth.SecretClientSecret)
+	if err != nil {
+		return "", err
+	}
+	refreshTokenRef, err := auth.SecretRef(profileName, auth.SecretRefreshToken)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(clientSecret) != "" {
+		if err := store.Set(clientSecretRef, clientSecret); err != nil {
+			return "", err
+		}
+	} else if strings.TrimSpace(existing.ClientSecretRef) == "" {
+		return "", errors.New("client secret is required")
+	}
+
+	now := time.Now().UTC()
+	profile := config.Profile{
+		Provider:        config.ProviderLinkedIn,
+		Domain:          config.DefaultDomain,
+		LinkedInVersion: resolvedVersion,
+		ClientID:        resolvedClientID,
+		TokenRef:        tokenRef,
+		ClientSecretRef: clientSecretRef,
+		RefreshTokenRef: refreshTokenRef,
+		Scopes:          resolvedScopes,
+		IssuedAt:        now.Format(time.RFC3339),
+		ExpiresAt:       now.Add(defaultLinkedInProfileTTL).Format(time.RFC3339),
+		LastValidatedAt: now.Format(time.RFC3339),
+	}
+	if existing.IssuedAt != "" {
+		profile.IssuedAt = existing.IssuedAt
+	}
+	if existing.ExpiresAt != "" {
+		profile.ExpiresAt = existing.ExpiresAt
+	}
+	if err := cfg.UpsertProfile(profileName, profile); err != nil {
+		return "", err
+	}
+	if err := config.Save(configPath, cfg); err != nil {
+		return "", err
+	}
+	return resolvedVersion, nil
+}
+
+func linkedinSetupInput(profileName string, redirectURI string, scopes []string, timeout time.Duration, openBrowser bool) linkedin.SetupInput {
+	_ = profileName
+	return linkedin.SetupInput{
+		RedirectURI: strings.TrimSpace(redirectURI),
+		Scopes:      scopes,
+		OpenBrowser: openBrowser,
+		Timeout:     timeout,
+	}
+}

--- a/internal/cli/cmd/li_auth.go
+++ b/internal/cli/cmd/li_auth.go
@@ -49,7 +49,9 @@ func newLIAuthSetupCommand(runtime Runtime) *cobra.Command {
 			if err != nil {
 				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(resolvedVersion))
 			}
-			result, err := svc.Setup(cmd.Context(), profileName, linkedinSetupInput(profileName, resolvedRedirectURI, csvToSlice(scopesRaw), authFlow, timeout, openBrowser))
+			result, err := svc.Setup(cmd.Context(), profileName, linkedinSetupInput(profileName, resolvedRedirectURI, csvToSlice(scopesRaw), authFlow, timeout, openBrowser, func(authURL string) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Open this URL and complete LinkedIn login:\n%s\n", authURL)
+			}))
 			if err != nil {
 				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(resolvedVersion))
 			}
@@ -269,12 +271,13 @@ func bootstrapLinkedInProfile(profileName string, clientID string, clientSecret 
 	return resolvedVersion, nil
 }
 
-func linkedinSetupInput(profileName string, redirectURI string, scopes []string, authFlow string, timeout time.Duration, openBrowser bool) linkedin.SetupInput {
+func linkedinSetupInput(profileName string, redirectURI string, scopes []string, authFlow string, timeout time.Duration, openBrowser bool, onAuthURL func(string)) linkedin.SetupInput {
 	_ = profileName
 	return linkedin.SetupInput{
 		RedirectURI: strings.TrimSpace(redirectURI),
 		Scopes:      scopes,
 		AuthFlow:    strings.TrimSpace(authFlow),
+		OnAuthURL:   onAuthURL,
 		OpenBrowser: openBrowser,
 		Timeout:     timeout,
 	}

--- a/internal/cli/cmd/li_auth.go
+++ b/internal/cli/cmd/li_auth.go
@@ -35,9 +35,13 @@ func newLIAuthSetupCommand(runtime Runtime) *cobra.Command {
 			if err != nil {
 				return writeCommandError(cmd, runtime, "meta li auth setup", err)
 			}
+			listenerURI, err := localCallbackRedirectURI(listenAddr)
+			if err != nil {
+				return writeCommandError(cmd, runtime, "meta li auth setup", err)
+			}
 			resolvedRedirectURI := strings.TrimSpace(redirectURI)
 			if resolvedRedirectURI == "" {
-				resolvedRedirectURI = fmt.Sprintf("http://%s%s", strings.TrimSpace(listenAddr), defaultAuthCallbackPath)
+				resolvedRedirectURI = listenerURI
 			}
 
 			resolvedVersion, err := bootstrapLinkedInProfile(profileName, clientID, clientSecret, version, csvToSlice(scopesRaw))
@@ -49,7 +53,7 @@ func newLIAuthSetupCommand(runtime Runtime) *cobra.Command {
 			if err != nil {
 				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(resolvedVersion))
 			}
-			result, err := svc.Setup(cmd.Context(), profileName, linkedinSetupInput(profileName, resolvedRedirectURI, csvToSlice(scopesRaw), authFlow, timeout, openBrowser, func(authURL string) {
+			result, err := svc.Setup(cmd.Context(), profileName, linkedinSetupInput(profileName, listenerURI, resolvedRedirectURI, csvToSlice(scopesRaw), authFlow, timeout, openBrowser, func(authURL string) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Open this URL and complete LinkedIn login:\n%s\n", authURL)
 			}))
 			if err != nil {
@@ -271,9 +275,10 @@ func bootstrapLinkedInProfile(profileName string, clientID string, clientSecret 
 	return resolvedVersion, nil
 }
 
-func linkedinSetupInput(profileName string, redirectURI string, scopes []string, authFlow string, timeout time.Duration, openBrowser bool, onAuthURL func(string)) linkedin.SetupInput {
+func linkedinSetupInput(profileName string, listenerURI string, redirectURI string, scopes []string, authFlow string, timeout time.Duration, openBrowser bool, onAuthURL func(string)) linkedin.SetupInput {
 	_ = profileName
 	return linkedin.SetupInput{
+		ListenerURI: strings.TrimSpace(listenerURI),
 		RedirectURI: strings.TrimSpace(redirectURI),
 		Scopes:      scopes,
 		AuthFlow:    strings.TrimSpace(authFlow),

--- a/internal/cli/cmd/li_auth.go
+++ b/internal/cli/cmd/li_auth.go
@@ -19,6 +19,7 @@ func newLIAuthSetupCommand(runtime Runtime) *cobra.Command {
 		clientSecret string
 		version      string
 		scopesRaw    string
+		authFlow     string
 		listenAddr   string
 		redirectURI  string
 		timeout      time.Duration
@@ -48,7 +49,7 @@ func newLIAuthSetupCommand(runtime Runtime) *cobra.Command {
 			if err != nil {
 				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(resolvedVersion))
 			}
-			result, err := svc.Setup(cmd.Context(), profileName, linkedinSetupInput(profileName, resolvedRedirectURI, csvToSlice(scopesRaw), timeout, openBrowser))
+			result, err := svc.Setup(cmd.Context(), profileName, linkedinSetupInput(profileName, resolvedRedirectURI, csvToSlice(scopesRaw), authFlow, timeout, openBrowser))
 			if err != nil {
 				return writeCommandErrorWithProvider(cmd, runtime, "meta li auth setup", err, linkedInEnvelopeProvider(resolvedVersion))
 			}
@@ -61,6 +62,7 @@ func newLIAuthSetupCommand(runtime Runtime) *cobra.Command {
 	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "LinkedIn application client secret")
 	cmd.Flags().StringVar(&version, "linkedin-version", "", "LinkedIn API version header (YYYYMM)")
 	cmd.Flags().StringVar(&scopesRaw, "scopes", "", "Comma-separated OAuth scopes")
+	cmd.Flags().StringVar(&authFlow, "auth-flow", string(linkedin.AuthFlowStandard), "LinkedIn authorization flow: standard|native-pkce")
 	cmd.Flags().StringVar(&listenAddr, "listen-addr", defaultAuthListenAddr, "Local callback listener address")
 	cmd.Flags().StringVar(&redirectURI, "redirect-uri", "", "OAuth redirect URI; defaults to http://<listen-addr>/oauth/callback")
 	cmd.Flags().DurationVar(&timeout, "timeout", defaultAuthTimeout, "OAuth callback timeout")
@@ -267,11 +269,12 @@ func bootstrapLinkedInProfile(profileName string, clientID string, clientSecret 
 	return resolvedVersion, nil
 }
 
-func linkedinSetupInput(profileName string, redirectURI string, scopes []string, timeout time.Duration, openBrowser bool) linkedin.SetupInput {
+func linkedinSetupInput(profileName string, redirectURI string, scopes []string, authFlow string, timeout time.Duration, openBrowser bool) linkedin.SetupInput {
 	_ = profileName
 	return linkedin.SetupInput{
 		RedirectURI: strings.TrimSpace(redirectURI),
 		Scopes:      scopes,
+		AuthFlow:    strings.TrimSpace(authFlow),
 		OpenBrowser: openBrowser,
 		Timeout:     timeout,
 	}

--- a/internal/cli/cmd/li_insights.go
+++ b/internal/cli/cmd/li_insights.go
@@ -99,7 +99,7 @@ func newLIInsightsRunLikeCommand(runtime Runtime, commandName string, short stri
 	cmd.Flags().StringVar(&until, "until", "", "Inclusive end date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&timeGranularity, "time-granularity", string(linkedin.GranularityDaily), "ALL|DAILY|MONTHLY")
 	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
-	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Pagination token (numeric offset for LinkedIn analytics)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum rows to return")
 	cmd.Flags().BoolVar(&followNext, "follow-next", false, "Follow pagination")
 	mustMarkFlagRequired(cmd, "account-urns")
@@ -121,14 +121,30 @@ func newLIInsightsMetricsListCommand(runtime Runtime) *cobra.Command {
 				if strings.TrimSpace(pack) != "" && string(current) != strings.ToLower(strings.TrimSpace(pack)) {
 					continue
 				}
+				if linkedin.MetricPackUsesDefaultFields(current) {
+					defaultMetrics, err := linkedin.MetricPackDefaultMetrics(current)
+					if err != nil {
+						return writeCommandError(cmd, runtime, "meta li insights metrics list", err)
+					}
+					data = append(data, map[string]any{
+						"metric_pack":      current,
+						"metric":           "",
+						"mode":             "default",
+						"projected_fields": false,
+						"default_metrics":  linkedInMetricStrings(defaultMetrics),
+					})
+					continue
+				}
 				metrics, err := linkedin.MetricPackMetrics(current)
 				if err != nil {
 					return writeCommandError(cmd, runtime, "meta li insights metrics list", err)
 				}
 				for _, metric := range metrics {
 					data = append(data, map[string]any{
-						"metric_pack": current,
-						"metric":      metric,
+						"metric_pack":      current,
+						"metric":           metric,
+						"mode":             "fields",
+						"projected_fields": true,
 					})
 				}
 			}
@@ -215,4 +231,12 @@ func parseLinkedInDateRange(since string, until string) (*linkedin.DateRange, er
 		Start: linkedin.DateValue{Year: start.Year(), Month: int(start.Month()), Day: start.Day()},
 		End:   linkedin.DateValue{Year: end.Year(), Month: int(end.Month()), Day: end.Day()},
 	}, nil
+}
+
+func linkedInMetricStrings(metrics []linkedin.Metric) []string {
+	out := make([]string, 0, len(metrics))
+	for _, metric := range metrics {
+		out = append(out, string(metric))
+	}
+	return out
 }

--- a/internal/cli/cmd/li_insights.go
+++ b/internal/cli/cmd/li_insights.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bilalbayram/metacli/internal/linkedin"
+	"github.com/spf13/cobra"
+)
+
+func newLIInsightsRunCommand(runtime Runtime) *cobra.Command {
+	return newLIInsightsRunLikeCommand(runtime, "meta li insights run", "Run LinkedIn ad analytics", linkedin.QueryAnalytics)
+}
+
+func newLIInsightsDemographicRunCommand(runtime Runtime) *cobra.Command {
+	return newLIInsightsRunLikeCommand(runtime, "meta li insights demographic run", "Run LinkedIn demographic reporting", linkedin.QueryDemographic)
+}
+
+func newLIInsightsRunLikeCommand(runtime Runtime, commandName string, short string, kind linkedin.QueryKind) *cobra.Command {
+	var (
+		profile         string
+		version         string
+		accountURNsRaw  string
+		level           string
+		metricPack      string
+		metricsRaw      string
+		pivot           string
+		pivotsRaw       string
+		since           string
+		until           string
+		timeGranularity string
+		pageSize        int
+		pageToken       string
+		limit           int
+		followNext      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			accountURNs, err := parseLinkedInURNs(accountURNsRaw, linkedin.NormalizeSponsoredAccountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			dateRange, err := parseLinkedInDateRange(since, until)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+
+			input := linkedin.ReportingInput{
+				QueryKind:       kind,
+				AccountURNs:     accountURNs,
+				Level:           linkedin.ReportingLevel(strings.ToUpper(strings.TrimSpace(level))),
+				MetricPack:      linkedin.MetricPack(strings.ToLower(strings.TrimSpace(metricPack))),
+				Pivot:           linkedin.Pivot(strings.ToUpper(strings.TrimSpace(pivot))),
+				Pivots:          parseLinkedInPivots(pivotsRaw),
+				DateRange:       dateRange,
+				TimeGranularity: linkedin.TimeGranularity(strings.ToUpper(strings.TrimSpace(timeGranularity))),
+				PageSize:        pageSize,
+				PageToken:       strings.TrimSpace(pageToken),
+				Limit:           limit,
+				FollowNext:      followNext,
+			}
+			metrics, err := linkedin.NormalizeMetrics(csvToSlice(metricsRaw))
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			input.Metrics = metrics
+
+			result, err := (&linkedin.ReportingService{Client: client}).Run(cmd.Context(), input)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, result, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURNsRaw, "account-urns", "", "Comma-separated sponsored account URNs or ids")
+	cmd.Flags().StringVar(&level, "level", string(linkedin.LevelCampaign), "Reporting level: ACCOUNT|CAMPAIGN_GROUP|CAMPAIGN|CREATIVE")
+	cmd.Flags().StringVar(&metricPack, "metric-pack", string(linkedin.PackBasic), "Metric pack: basic|delivery|leadgen|video|b2b")
+	cmd.Flags().StringVar(&metricsRaw, "metrics", "", "Comma-separated metrics override")
+	cmd.Flags().StringVar(&pivot, "pivot", "", "Primary pivot")
+	cmd.Flags().StringVar(&pivotsRaw, "pivots", "", "Comma-separated pivots")
+	cmd.Flags().StringVar(&since, "since", "", "Inclusive start date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&until, "until", "", "Inclusive end date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&timeGranularity, "time-granularity", string(linkedin.GranularityDaily), "ALL|DAILY|MONTHLY")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum rows to return")
+	cmd.Flags().BoolVar(&followNext, "follow-next", false, "Follow pagination")
+	mustMarkFlagRequired(cmd, "account-urns")
+	mustMarkFlagRequired(cmd, "since")
+	mustMarkFlagRequired(cmd, "until")
+	return cmd
+}
+
+func newLIInsightsMetricsListCommand(runtime Runtime) *cobra.Command {
+	var pack string
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List supported LinkedIn reporting metrics",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			data := make([]map[string]any, 0)
+			packs := []linkedin.MetricPack{linkedin.PackBasic, linkedin.PackDelivery, linkedin.PackLeadGen, linkedin.PackVideo, linkedin.PackB2B}
+			for _, current := range packs {
+				if strings.TrimSpace(pack) != "" && string(current) != strings.ToLower(strings.TrimSpace(pack)) {
+					continue
+				}
+				metrics, err := linkedin.MetricPackMetrics(current)
+				if err != nil {
+					return writeCommandError(cmd, runtime, "meta li insights metrics list", err)
+				}
+				for _, metric := range metrics {
+					data = append(data, map[string]any{
+						"metric_pack": current,
+						"metric":      metric,
+					})
+				}
+			}
+			return writeSuccess(cmd, runtime, "meta li insights metrics list", data, nil, nil)
+		},
+	}
+	listCmd.Flags().StringVar(&pack, "metric-pack", "", "Optional metric pack filter")
+
+	cmd := newLISubcommandGroup("metrics", "LinkedIn reporting metric commands")
+	cmd.AddCommand(listCmd)
+	return cmd
+}
+
+func newLIInsightsPivotsListCommand(runtime Runtime) *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List supported LinkedIn reporting pivots",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pivots := []linkedin.Pivot{
+				linkedin.PivotAccount,
+				linkedin.PivotCampaignGroup,
+				linkedin.PivotCampaign,
+				linkedin.PivotCreative,
+				linkedin.PivotDay,
+				linkedin.PivotMonth,
+				linkedin.PivotMemberCountry,
+				linkedin.PivotMemberRegion,
+				linkedin.PivotMemberSeniority,
+				linkedin.PivotMemberCompany,
+				linkedin.PivotMemberIndustry,
+				linkedin.PivotMemberJobFunction,
+			}
+			rows := make([]map[string]any, 0, len(pivots))
+			for _, pivot := range pivots {
+				rows = append(rows, map[string]any{
+					"pivot":       pivot,
+					"demographic": strings.HasPrefix(string(pivot), "MEMBER_"),
+				})
+			}
+			return writeSuccess(cmd, runtime, "meta li insights pivots list", rows, nil, nil)
+		},
+	}
+	cmd := newLISubcommandGroup("pivots", "LinkedIn reporting pivot commands")
+	cmd.AddCommand(listCmd)
+	return cmd
+}
+
+func parseLinkedInURNs(raw string, normalize func(string) (linkedin.URN, error)) ([]linkedin.URN, error) {
+	values := csvToSlice(raw)
+	if len(values) == 0 {
+		return nil, errors.New("at least one URN is required")
+	}
+	out := make([]linkedin.URN, 0, len(values))
+	for _, value := range values {
+		urn, err := normalize(value)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, urn)
+	}
+	return out, nil
+}
+
+func parseLinkedInPivots(raw string) []linkedin.Pivot {
+	values := csvToSlice(raw)
+	out := make([]linkedin.Pivot, 0, len(values))
+	for _, value := range values {
+		out = append(out, linkedin.Pivot(strings.ToUpper(strings.TrimSpace(value))))
+	}
+	return out
+}
+
+func parseLinkedInDateRange(since string, until string) (*linkedin.DateRange, error) {
+	start, err := time.Parse("2006-01-02", strings.TrimSpace(since))
+	if err != nil {
+		return nil, fmt.Errorf("parse --since: %w", err)
+	}
+	end, err := time.Parse("2006-01-02", strings.TrimSpace(until))
+	if err != nil {
+		return nil, fmt.Errorf("parse --until: %w", err)
+	}
+	return &linkedin.DateRange{
+		Start: linkedin.DateValue{Year: start.Year(), Month: int(start.Month()), Day: start.Day()},
+		End:   linkedin.DateValue{Year: end.Year(), Month: int(end.Month()), Day: end.Day()},
+	}, nil
+}

--- a/internal/cli/cmd/li_insights_test.go
+++ b/internal/cli/cmd/li_insights_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestLIInsightsMetricsListRepresentsBasicAsDefaultMode(t *testing.T) {
+	cmd := newLIInsightsMetricsListCommand(testRuntime("prod"))
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute metrics list: %v", err)
+	}
+
+	envelope := decodeEnvelope(t, stdout.Bytes())
+	assertEnvelopeBasics(t, envelope, "meta li insights metrics list")
+
+	data, ok := envelope["data"].([]any)
+	if !ok {
+		t.Fatalf("expected data array, got %T", envelope["data"])
+	}
+	foundBasic := false
+	for _, raw := range data {
+		row, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("expected object row, got %T", raw)
+		}
+		pack, _ := row["metric_pack"].(string)
+		if pack != "basic" {
+			continue
+		}
+		foundBasic = true
+		if got, _ := row["mode"].(string); got != "default" {
+			t.Fatalf("unexpected basic mode %q", got)
+		}
+		if projected, _ := row["projected_fields"].(bool); projected {
+			t.Fatalf("expected basic pack to omit projected fields")
+		}
+		defaultMetrics, ok := row["default_metrics"].([]any)
+		if !ok || len(defaultMetrics) != 2 {
+			t.Fatalf("unexpected default metrics %#v", row["default_metrics"])
+		}
+		if metric, _ := row["metric"].(string); metric != "" {
+			t.Fatalf("expected empty explicit metric for basic, got %q", metric)
+		}
+	}
+	if !foundBasic {
+		t.Fatal("expected basic metric pack row")
+	}
+}

--- a/internal/cli/cmd/li_resources.go
+++ b/internal/cli/cmd/li_resources.go
@@ -1,0 +1,958 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bilalbayram/metacli/internal/linkedin"
+	"github.com/spf13/cobra"
+)
+
+func newLIAccountListCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile   string
+		version   string
+		search    string
+		pageSize  int
+		pageToken string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List LinkedIn ad accounts visible to the active profile",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			creds, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li account list", err, linkedInEnvelopeProvider(version))
+			}
+			_ = creds
+			result, err := service.ListAdAccounts(cmd.Context(), search, pageSize, pageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li account list", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li account list", result.Elements, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&search, "search", "", "Optional account search expression")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	return cmd
+}
+
+func newLIAccountRolesCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile    string
+		version    string
+		accountURN string
+		pageSize   int
+		pageToken  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "roles",
+		Short: "List role assignments for a LinkedIn ad account",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li account roles", err, linkedInEnvelopeProvider(version))
+			}
+			normalized, err := linkedin.NormalizeSponsoredAccountURN(accountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li account roles", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := service.ListAccountRoles(cmd.Context(), normalized, pageSize, pageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li account roles", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li account roles", result.Elements, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	mustMarkFlagRequired(cmd, "account-urn")
+	return cmd
+}
+
+func newLIOrganizationListCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile   string
+		version   string
+		search    string
+		pageSize  int
+		pageToken string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List LinkedIn organizations",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li organization list", err, linkedInEnvelopeProvider(version))
+			}
+			result, err := service.ListOrganizations(cmd.Context(), search, pageSize, pageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li organization list", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li organization list", result.Elements, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&search, "search", "", "Optional organization search expression")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	return cmd
+}
+
+func newLIOrganizationGetCommand(runtime Runtime) *cobra.Command {
+	return newLIGetEntityCommand(runtime, "meta li organization get", "Get a LinkedIn organization", "/rest/organizations")
+}
+
+func newLIOrganizationRolesCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile         string
+		version         string
+		organizationURN string
+		pageSize        int
+		pageToken       string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "roles",
+		Short: "List role assignments for a LinkedIn organization",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li organization roles", err, linkedInEnvelopeProvider(version))
+			}
+			normalized, err := linkedin.NormalizeOrganizationURN(organizationURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li organization roles", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := service.ListOrganizationRoles(cmd.Context(), normalized, pageSize, pageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li organization roles", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li organization roles", result.Elements, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&organizationURN, "organization-urn", "", "Organization URN or numeric organization id")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	mustMarkFlagRequired(cmd, "organization-urn")
+	return cmd
+}
+
+func newLICampaignGroupListCommand(runtime Runtime) *cobra.Command {
+	return newLIListByAccountCommand(runtime, "meta li campaign-group list", "List LinkedIn campaign groups", func(service *linkedin.AdsService, ctx context.Context, account linkedin.URN, search string, pageSize int, pageToken string) (*linkedin.CollectionResult, error) {
+		return service.ListCampaignGroups(ctx, account, search, pageSize, pageToken)
+	})
+}
+
+func newLICampaignGroupGetCommand(runtime Runtime) *cobra.Command {
+	return newLIGetEntityCommand(runtime, "meta li campaign-group get", "Get a LinkedIn campaign group", "/rest/adCampaignGroups")
+}
+
+func newLICampaignGroupUpdateCommand(runtime Runtime) *cobra.Command {
+	return newLIUpdateEntityCommand(runtime, "meta li campaign-group update", "Update a LinkedIn campaign group", "/rest/adCampaignGroups", "PARTIAL_UPDATE", nil)
+}
+
+func newLICampaignGroupPauseCommand(runtime Runtime) *cobra.Command {
+	return newLIStatusEntityCommand(runtime, "pause", "meta li campaign-group pause", "Pause a LinkedIn campaign group", "/rest/adCampaignGroups", "status", "PAUSED")
+}
+
+func newLICampaignGroupResumeCommand(runtime Runtime) *cobra.Command {
+	return newLIStatusEntityCommand(runtime, "resume", "meta li campaign-group resume", "Resume a LinkedIn campaign group", "/rest/adCampaignGroups", "status", "ACTIVE")
+}
+
+func newLICampaignListCommand(runtime Runtime) *cobra.Command {
+	return newLIListByAccountCommand(runtime, "meta li campaign list", "List LinkedIn campaigns", func(service *linkedin.AdsService, ctx context.Context, account linkedin.URN, search string, pageSize int, pageToken string) (*linkedin.CollectionResult, error) {
+		return service.ListCampaigns(ctx, account, search, pageSize, pageToken)
+	})
+}
+
+func newLICampaignGetCommand(runtime Runtime) *cobra.Command {
+	return newLIGetEntityCommand(runtime, "meta li campaign get", "Get a LinkedIn campaign", "/rest/adCampaigns")
+}
+
+func newLICampaignCreateCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile               string
+		version               string
+		accountURN            string
+		jsonRaw               string
+		confirmBudgetChange   bool
+		confirmScheduleChange bool
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a LinkedIn campaign",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			body, err := parseJSONObjectBody(jsonRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign create", err, linkedInEnvelopeProvider(version))
+			}
+			if budgetPresent(body) && !confirmBudgetChange {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign create", errors.New("campaign budget mutations require --confirm-budget-change"), linkedInEnvelopeProvider(version))
+			}
+			if schedulePresent(body) && !confirmScheduleChange {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign create", errors.New("campaign schedule mutations require --confirm-schedule-change"), linkedInEnvelopeProvider(version))
+			}
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign create", err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign create", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			account, err := linkedin.NormalizeSponsoredAccountURN(accountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign create", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			if _, exists := body["account"]; !exists {
+				body["account"] = account.String()
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:   http.MethodPost,
+				Path:     "/rest/adCampaigns",
+				Version:  resolvedVersion,
+				JSONBody: body,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign create", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li campaign create", resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().StringVar(&jsonRaw, "json", "", "Inline JSON payload")
+	cmd.Flags().BoolVar(&confirmBudgetChange, "confirm-budget-change", false, "Acknowledge campaign budget mutations")
+	cmd.Flags().BoolVar(&confirmScheduleChange, "confirm-schedule-change", false, "Acknowledge campaign schedule mutations")
+	mustMarkFlagRequired(cmd, "account-urn")
+	mustMarkFlagRequired(cmd, "json")
+	return cmd
+}
+
+func newLICampaignUpdateCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile               string
+		version               string
+		jsonRaw               string
+		confirmBudgetChange   bool
+		confirmScheduleChange bool
+	)
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a LinkedIn campaign",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body, err := parseJSONObjectBody(jsonRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign update", err, linkedInEnvelopeProvider(version))
+			}
+			if budgetPresent(body) && !confirmBudgetChange {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign update", errors.New("campaign budget mutations require --confirm-budget-change"), linkedInEnvelopeProvider(version))
+			}
+			if schedulePresent(body) && !confirmScheduleChange {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign update", errors.New("campaign schedule mutations require --confirm-schedule-change"), linkedInEnvelopeProvider(version))
+			}
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign update", err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign update", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:   http.MethodPost,
+				Path:     liEntityPath("/rest/adCampaigns", args[0]),
+				Version:  resolvedVersion,
+				Headers:  linkedInRestliHeaders("PARTIAL_UPDATE"),
+				JSONBody: body,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li campaign update", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li campaign update", resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&jsonRaw, "json", "", "Inline JSON payload")
+	cmd.Flags().BoolVar(&confirmBudgetChange, "confirm-budget-change", false, "Acknowledge campaign budget mutations")
+	cmd.Flags().BoolVar(&confirmScheduleChange, "confirm-schedule-change", false, "Acknowledge campaign schedule mutations")
+	mustMarkFlagRequired(cmd, "json")
+	return cmd
+}
+
+func newLICampaignPauseCommand(runtime Runtime) *cobra.Command {
+	return newLIStatusEntityCommand(runtime, "pause", "meta li campaign pause", "Pause a LinkedIn campaign", "/rest/adCampaigns", "status", "PAUSED")
+}
+
+func newLICampaignResumeCommand(runtime Runtime) *cobra.Command {
+	return newLIStatusEntityCommand(runtime, "resume", "meta li campaign resume", "Resume a LinkedIn campaign", "/rest/adCampaigns", "status", "ACTIVE")
+}
+
+func newLICreativeListCommand(runtime Runtime) *cobra.Command {
+	return newLIListByAccountCommand(runtime, "meta li creative list", "List LinkedIn creatives", func(service *linkedin.AdsService, ctx context.Context, account linkedin.URN, search string, pageSize int, pageToken string) (*linkedin.CollectionResult, error) {
+		return service.ListCreatives(ctx, account, search, pageSize, pageToken)
+	})
+}
+
+func newLICreativeGetCommand(runtime Runtime) *cobra.Command {
+	return newLIGetEntityCommand(runtime, "meta li creative get", "Get a LinkedIn creative", "/rest/creatives")
+}
+
+func newLICreativeCreateCommand(runtime Runtime) *cobra.Command {
+	return newLICreateEntityCommand(runtime, "meta li creative create", "Create a LinkedIn creative", "/rest/creatives", true, validateLinkedInCreativeWrite)
+}
+
+func newLICreativeUpdateCommand(runtime Runtime) *cobra.Command {
+	return newLIUpdateEntityCommand(runtime, "meta li creative update", "Update a LinkedIn creative", "/rest/creatives", "PARTIAL_UPDATE", validateLinkedInCreativeWrite)
+}
+
+func newLICreativeArchiveCommand(runtime Runtime) *cobra.Command {
+	return newLIStatusEntityCommand(runtime, "archive", "meta li creative archive", "Archive a LinkedIn creative", "/rest/creatives", "intendedStatus", "ARCHIVED")
+}
+
+func newLILeadFormListCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile    string
+		version    string
+		accountURN string
+		pageSize   int
+		pageToken  string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List LinkedIn lead forms for an account",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead-form list", err, linkedInEnvelopeProvider(version))
+			}
+			account, err := linkedin.NormalizeSponsoredAccountURN(accountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead-form list", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := service.ListLeadForms(cmd.Context(), account, pageSize, pageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead-form list", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li lead-form list", result.Elements, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	mustMarkFlagRequired(cmd, "account-urn")
+	return cmd
+}
+
+func newLILeadFormGetCommand(runtime Runtime) *cobra.Command {
+	return newLIGetEntityCommand(runtime, "meta li lead-form get", "Get a LinkedIn lead form", "/rest/leadForms")
+}
+
+func newLILeadFormCreateCommand(runtime Runtime) *cobra.Command {
+	return newLICreateEntityCommand(runtime, "meta li lead-form create", "Create a LinkedIn lead form", "/rest/leadForms", true, nil)
+}
+
+func newLILeadListCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile    string
+		version    string
+		accountURN string
+		pageSize   int
+		pageToken  string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List LinkedIn leads for an account",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead list", err, linkedInEnvelopeProvider(version))
+			}
+			account, err := linkedin.NormalizeSponsoredAccountURN(accountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead list", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := service.ListLeads(cmd.Context(), account, pageSize, pageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead list", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li lead list", result.Elements, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	mustMarkFlagRequired(cmd, "account-urn")
+	return cmd
+}
+
+func newLILeadGetCommand(runtime Runtime) *cobra.Command {
+	return newLIGetEntityCommand(runtime, "meta li lead get", "Get a LinkedIn lead", "/rest/leadFormResponses")
+}
+
+func newLILeadSyncCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile    string
+		version    string
+		accountURN string
+		pageSize   int
+		stateFile  string
+		reset      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Incrementally pull LinkedIn leads with stored cursor state",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			profileName, err := resolveLIProfileName(runtime, profile)
+			if err != nil {
+				return writeCommandError(cmd, runtime, "meta li lead sync", err)
+			}
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profileName, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead sync", err, linkedInEnvelopeProvider(version))
+			}
+			account, err := linkedin.NormalizeSponsoredAccountURN(accountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead sync", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			resolvedStateFile, err := resolveLILeadSyncStateFile(profileName, stateFile)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead sync", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			state, err := loadLILeadSyncState(resolvedStateFile, reset)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead sync", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := service.ListLeads(cmd.Context(), account, pageSize, state.PageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead sync", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			filtered, seenIDs := filterNewLeadRows(result.Elements, state.SeenIDs)
+			state.PageToken = ""
+			if result.Paging != nil {
+				state.PageToken = strings.TrimSpace(result.Paging.NextPageToken)
+			}
+			state.SeenIDs = seenIDs
+			if err := saveLILeadSyncState(resolvedStateFile, state); err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li lead sync", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li lead sync", map[string]any{
+				"rows":            filtered,
+				"next_page_token": state.PageToken,
+				"state_file":      resolvedStateFile,
+			}, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().IntVar(&pageSize, "page-size", 100, "Page size")
+	cmd.Flags().StringVar(&stateFile, "state-file", "", "State file path for incremental sync")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Reset stored sync state before pulling")
+	mustMarkFlagRequired(cmd, "account-urn")
+	return cmd
+}
+
+func newLILeadWebhookCommand(runtime Runtime) *cobra.Command {
+	cmd := newLISubcommandGroup("webhook", "LinkedIn lead webhook commands")
+	cmd.AddCommand(newLILeadWebhookSubscribeCommand(runtime))
+	cmd.AddCommand(newLILeadWebhookListCommand(runtime))
+	cmd.AddCommand(newLILeadWebhookDeleteCommand(runtime))
+	return cmd
+}
+
+func newLILeadWebhookSubscribeCommand(runtime Runtime) *cobra.Command {
+	return newLICreateEntityCommand(runtime, "meta li lead webhook subscribe", "Subscribe a LinkedIn lead webhook", "/rest/leadWebhookSubscriptions", false, nil)
+}
+
+func newLILeadWebhookListCommand(runtime Runtime) *cobra.Command {
+	return newLIListPathCommand(runtime, "meta li lead webhook list", "List LinkedIn lead webhook subscriptions", "/rest/leadWebhookSubscriptions")
+}
+
+func newLILeadWebhookDeleteCommand(runtime Runtime) *cobra.Command {
+	return newLIDeleteEntityCommand(runtime, "meta li lead webhook delete", "Delete a LinkedIn lead webhook subscription", "/rest/leadWebhookSubscriptions")
+}
+
+func resolveLIAdsService(runtime Runtime, profile string, version string) (*ProfileCredentials, string, *linkedin.AdsService, error) {
+	creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	client, err := newLinkedInClient(creds, resolvedVersion)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return creds, resolvedVersion, linkedin.NewAdsService(client), nil
+}
+
+func newLIListPathCommand(runtime Runtime, commandName string, short string, path string) *cobra.Command {
+	var (
+		profile   string
+		version   string
+		pageSize  int
+		pageToken string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			query := map[string]string{}
+			if pageSize > 0 {
+				query[linkedin.DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+			}
+			if strings.TrimSpace(pageToken) != "" {
+				query[linkedin.DefaultPageTokenParam] = strings.TrimSpace(pageToken)
+			}
+			rows := make([]map[string]any, 0)
+			paging, err := client.FetchCollection(cmd.Context(), linkedin.Request{
+				Method:  http.MethodGet,
+				Path:    path,
+				Version: resolvedVersion,
+				Query:   query,
+			}, linkedin.PaginationOptions{FollowNext: true, PageSize: pageSize, PageToken: pageToken}, func(row map[string]any) error {
+				rows = append(rows, row)
+				return nil
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, rows, paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	return cmd
+}
+
+func newLIListByAccountCommand(runtime Runtime, commandName string, short string, listFn func(*linkedin.AdsService, context.Context, linkedin.URN, string, int, string) (*linkedin.CollectionResult, error)) *cobra.Command {
+	var (
+		profile    string
+		version    string
+		accountURN string
+		search     string
+		pageSize   int
+		pageToken  string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			account, err := linkedin.NormalizeSponsoredAccountURN(accountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			result, err := listFn(service, cmd.Context(), account, search, pageSize, pageToken)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, result.Elements, result.Paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().StringVar(&search, "search", "", "Optional search expression")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	mustMarkFlagRequired(cmd, "account-urn")
+	return cmd
+}
+
+func newLIGetEntityCommand(runtime Runtime, commandName string, short string, basePath string) *cobra.Command {
+	var (
+		profile string
+		version string
+	)
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:  http.MethodGet,
+				Path:    liEntityPath(basePath, args[0]),
+				Version: resolvedVersion,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	return cmd
+}
+
+func newLICreateEntityCommand(runtime Runtime, commandName string, short string, path string, requireAccount bool, validator func(map[string]any) error) *cobra.Command {
+	var (
+		profile    string
+		version    string
+		accountURN string
+		jsonRaw    string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			body, err := parseJSONObjectBody(jsonRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			if requireAccount {
+				account, normalizeErr := linkedin.NormalizeSponsoredAccountURN(accountURN)
+				if normalizeErr != nil {
+					return writeCommandErrorWithProvider(cmd, runtime, commandName, normalizeErr, linkedInEnvelopeProvider(resolvedVersion))
+				}
+				if _, exists := body["account"]; !exists {
+					body["account"] = account.String()
+				}
+			}
+			if validator != nil {
+				if err := validator(body); err != nil {
+					return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+				}
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:   http.MethodPost,
+				Path:     path,
+				Version:  resolvedVersion,
+				JSONBody: body,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().StringVar(&jsonRaw, "json", "", "Inline JSON payload")
+	if requireAccount {
+		mustMarkFlagRequired(cmd, "account-urn")
+	}
+	mustMarkFlagRequired(cmd, "json")
+	return cmd
+}
+
+func newLIUpdateEntityCommand(runtime Runtime, commandName string, short string, basePath string, restliMethod string, validator func(map[string]any) error) *cobra.Command {
+	var (
+		profile string
+		version string
+		jsonRaw string
+	)
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			body, err := parseJSONObjectBody(jsonRaw)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			if validator != nil {
+				if err := validator(body); err != nil {
+					return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+				}
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:   http.MethodPost,
+				Path:     liEntityPath(basePath, args[0]),
+				Version:  resolvedVersion,
+				Headers:  linkedInRestliHeaders(restliMethod),
+				JSONBody: body,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&jsonRaw, "json", "", "Inline JSON payload")
+	mustMarkFlagRequired(cmd, "json")
+	return cmd
+}
+
+func newLIStatusEntityCommand(runtime Runtime, use string, commandName string, short string, basePath string, field string, status string) *cobra.Command {
+	var (
+		profile string
+		version string
+		confirm bool
+	)
+	cmd := &cobra.Command{
+		Use:   use + " <id>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !confirm {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, errors.New("use --confirm to apply live status changes"), linkedInEnvelopeProvider(version))
+			}
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:   http.MethodPost,
+				Path:     liEntityPath(basePath, args[0]),
+				Version:  resolvedVersion,
+				Headers:  linkedInRestliHeaders("PARTIAL_UPDATE"),
+				JSONBody: map[string]any{field: status},
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm a live status mutation")
+	return cmd
+}
+
+func newLIDeleteEntityCommand(runtime Runtime, commandName string, short string, basePath string) *cobra.Command {
+	var (
+		profile string
+		version string
+	)
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			resp, err := client.Do(cmd.Context(), linkedin.Request{
+				Method:  http.MethodDelete,
+				Path:    liEntityPath(basePath, args[0]),
+				Version: resolvedVersion,
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, commandName, resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	return cmd
+}
+
+func liEntityPath(basePath string, id string) string {
+	return strings.TrimSuffix(basePath, "/") + "/" + url.PathEscape(strings.TrimSpace(id))
+}
+
+func parseJSONObjectBody(raw string) (map[string]any, error) {
+	body, err := parseRawJSONBody(raw)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return nil, errors.New("inline JSON payload is required")
+	}
+	object, ok := body.(map[string]any)
+	if !ok {
+		return nil, errors.New("inline JSON payload must be an object")
+	}
+	return object, nil
+}
+
+func validateLinkedInCampaignWrite(body map[string]any) error {
+	if len(body) == 0 {
+		return errors.New("campaign payload cannot be empty")
+	}
+	return nil
+}
+
+func validateLinkedInCreativeWrite(body map[string]any) error {
+	if len(body) == 0 {
+		return errors.New("creative payload cannot be empty")
+	}
+	for _, key := range []string{"type", "creativeType"} {
+		if raw, ok := body[key].(string); ok && strings.TrimSpace(raw) != "" {
+			switch strings.ToUpper(strings.TrimSpace(raw)) {
+			case "SINGLE_IMAGE", "ARTICLE", "VIDEO", "LEAD_GEN", "LEADGEN":
+				return nil
+			default:
+				return fmt.Errorf("unsupported creative type %q", raw)
+			}
+		}
+	}
+	return nil
+}
+
+func budgetPresent(body map[string]any) bool {
+	for _, key := range []string{"dailyBudget", "lifetimeBudget", "totalBudget", "budget"} {
+		if _, ok := body[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func schedulePresent(body map[string]any) bool {
+	for _, key := range []string{"runSchedule", "schedule", "start", "end"} {
+		if _, ok := body[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+type liLeadSyncState struct {
+	PageToken string            `json:"page_token,omitempty"`
+	SeenIDs   map[string]string `json:"seen_ids,omitempty"`
+}
+
+func resolveLILeadSyncStateFile(profile string, stateFile string) (string, error) {
+	if strings.TrimSpace(stateFile) != "" {
+		return stateFile, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".meta", "linkedin-sync", profile+".json"), nil
+}
+
+func loadLILeadSyncState(path string, reset bool) (liLeadSyncState, error) {
+	if reset {
+		return liLeadSyncState{SeenIDs: map[string]string{}}, nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return liLeadSyncState{SeenIDs: map[string]string{}}, nil
+		}
+		return liLeadSyncState{}, err
+	}
+	state := liLeadSyncState{}
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return liLeadSyncState{}, err
+	}
+	if state.SeenIDs == nil {
+		state.SeenIDs = map[string]string{}
+	}
+	return state, nil
+}
+
+func saveLILeadSyncState(path string, state liLeadSyncState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o600)
+}
+
+func filterNewLeadRows(rows []map[string]any, seen map[string]string) ([]map[string]any, map[string]string) {
+	if seen == nil {
+		seen = map[string]string{}
+	}
+	filtered := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(fmt.Sprint(row["id"]))
+		if id == "" {
+			filtered = append(filtered, row)
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = id
+		filtered = append(filtered, row)
+	}
+	return filtered, seen
+}

--- a/internal/cli/cmd/li_resources.go
+++ b/internal/cli/cmd/li_resources.go
@@ -82,7 +82,7 @@ func newLIAccountRolesCommand(runtime Runtime) *cobra.Command {
 	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
 	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
 	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Page size")
-	cmd.Flags().StringVar(&pageToken, "page-token", "", "Cursor token")
+	cmd.Flags().StringVar(&pageToken, "page-token", "", "Pagination token (numeric offset for LinkedIn account roles)")
 	mustMarkFlagRequired(cmd, "account-urn")
 	return cmd
 }

--- a/internal/cli/cmd/li_support.go
+++ b/internal/cli/cmd/li_support.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bilalbayram/metacli/internal/auth"
+	"github.com/bilalbayram/metacli/internal/config"
+	"github.com/bilalbayram/metacli/internal/linkedin"
+	"github.com/bilalbayram/metacli/internal/output"
+)
+
+const (
+	defaultLinkedInProfileTTL = 5 * time.Minute
+)
+
+type linkedInProfileStore struct {
+	configPath string
+}
+
+func (s linkedInProfileStore) Get(name string) (linkedin.Profile, error) {
+	cfg, err := config.Load(s.configPath)
+	if err != nil {
+		return linkedin.Profile{}, err
+	}
+	resolvedName, profile, err := cfg.ResolveProfile(name)
+	if err != nil {
+		return linkedin.Profile{}, err
+	}
+	if provider := config.ResolveProvider(profile.Provider); provider != config.ProviderLinkedIn {
+		return linkedin.Profile{}, fmt.Errorf("profile %q uses provider %q, expected %q", resolvedName, provider, config.ProviderLinkedIn)
+	}
+	expiresAt, err := parseOptionalRFC3339(profile.ExpiresAt)
+	if err != nil {
+		return linkedin.Profile{}, fmt.Errorf("profile %q expires_at is invalid: %w", resolvedName, err)
+	}
+	return linkedin.Profile{
+		Provider:             config.ProviderLinkedIn,
+		LinkedInVersion:      strings.TrimSpace(profile.LinkedInVersion),
+		ClientID:             strings.TrimSpace(profile.ClientID),
+		ClientSecretRef:      strings.TrimSpace(profile.ClientSecretRef),
+		AccessTokenRef:       strings.TrimSpace(profile.TokenRef),
+		RefreshTokenRef:      strings.TrimSpace(profile.RefreshTokenRef),
+		Scopes:               append([]string(nil), profile.Scopes...),
+		AccessTokenExpiresAt: expiresAt,
+	}, nil
+}
+
+func (s linkedInProfileStore) Upsert(name string, liProfile linkedin.Profile) error {
+	cfg, err := config.LoadOrCreate(s.configPath)
+	if err != nil {
+		return err
+	}
+
+	profile := config.Profile{
+		Provider:        config.ProviderLinkedIn,
+		Domain:          config.DefaultDomain,
+		LinkedInVersion: strings.TrimSpace(liProfile.LinkedInVersion),
+		ClientID:        strings.TrimSpace(liProfile.ClientID),
+		TokenRef:        strings.TrimSpace(liProfile.AccessTokenRef),
+		ClientSecretRef: strings.TrimSpace(liProfile.ClientSecretRef),
+		RefreshTokenRef: strings.TrimSpace(liProfile.RefreshTokenRef),
+		Scopes:          append([]string(nil), liProfile.Scopes...),
+		IssuedAt:        time.Now().UTC().Format(time.RFC3339),
+		ExpiresAt:       formatOptionalRFC3339(liProfile.AccessTokenExpiresAt),
+		LastValidatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	if existingName, existing, err := cfg.ResolveProfile(name); err == nil && existingName != "" {
+		profile.IssuedAt = existing.IssuedAt
+		if profile.ExpiresAt == "" {
+			profile.ExpiresAt = existing.ExpiresAt
+		}
+		if profile.LinkedInVersion == "" {
+			profile.LinkedInVersion = existing.LinkedInVersion
+		}
+		if profile.ClientID == "" {
+			profile.ClientID = existing.ClientID
+		}
+		if profile.TokenRef == "" {
+			profile.TokenRef = existing.TokenRef
+		}
+		if profile.ClientSecretRef == "" {
+			profile.ClientSecretRef = existing.ClientSecretRef
+		}
+		if profile.RefreshTokenRef == "" {
+			profile.RefreshTokenRef = existing.RefreshTokenRef
+		}
+		if len(profile.Scopes) == 0 {
+			profile.Scopes = append([]string(nil), existing.Scopes...)
+		}
+	}
+
+	if profile.IssuedAt == "" {
+		profile.IssuedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if profile.ExpiresAt == "" {
+		profile.ExpiresAt = time.Now().UTC().Add(defaultLinkedInProfileTTL).Format(time.RFC3339)
+	}
+	if err := cfg.UpsertProfile(name, profile); err != nil {
+		return err
+	}
+	return config.Save(s.configPath, cfg)
+}
+
+func newLinkedInAuthService() (*linkedin.Service, error) {
+	configPath, err := config.DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	return linkedin.NewService(
+		nil,
+		linkedin.DefaultAuthBaseURL,
+		linkedin.DefaultAPIBaseURL,
+		linkedInProfileStore{configPath: configPath},
+		auth.NewSecretStore(),
+	), nil
+}
+
+func newLinkedInClient(creds *ProfileCredentials, version string) (*linkedin.Client, error) {
+	if creds == nil {
+		return nil, errors.New("profile credentials are required")
+	}
+	if creds.Provider != config.ProviderLinkedIn {
+		return nil, fmt.Errorf("profile %q uses provider %q, expected %q", creds.Name, creds.Provider, config.ProviderLinkedIn)
+	}
+	resolvedVersion := strings.TrimSpace(version)
+	if resolvedVersion == "" {
+		resolvedVersion = strings.TrimSpace(creds.Profile.LinkedInVersion)
+	}
+	if resolvedVersion == "" {
+		resolvedVersion = config.DefaultLinkedInVersion
+	}
+	return linkedin.NewClient(nil, linkedin.DefaultBaseURL, resolvedVersion, creds.Token), nil
+}
+
+func linkedInEnvelopeProvider(version string) *output.Provider {
+	return &output.Provider{
+		Name:    config.ProviderLinkedIn,
+		Version: strings.TrimSpace(version),
+	}
+}
+
+func resolveLinkedInProfileAndVersion(runtime Runtime, profile string, version string) (*ProfileCredentials, string, error) {
+	resolvedProfile := strings.TrimSpace(profile)
+	if resolvedProfile == "" {
+		resolvedProfile = runtime.ProfileName()
+	}
+	if resolvedProfile == "" {
+		return nil, "", errors.New("profile is required (--profile or global --profile)")
+	}
+
+	creds, err := loadLinkedInProfileCredentials(resolvedProfile)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resolvedVersion := strings.TrimSpace(version)
+	if resolvedVersion == "" {
+		resolvedVersion = strings.TrimSpace(creds.Profile.LinkedInVersion)
+	}
+	if resolvedVersion == "" {
+		resolvedVersion = config.DefaultLinkedInVersion
+	}
+	return creds, resolvedVersion, nil
+}
+
+func runLinkedInProfileAuthPreflight(profile string, selected config.Profile, configPath string) error {
+	if strings.TrimSpace(profile) == "" {
+		return errors.New("profile is required")
+	}
+	if config.ResolveProvider(selected.Provider) != config.ProviderLinkedIn {
+		return fmt.Errorf("profile %q is not a linkedin profile", profile)
+	}
+	expiresAt, err := parseOptionalRFC3339(selected.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("parse profile expiry: %w", err)
+	}
+	if expiresAt.IsZero() || expiresAt.After(time.Now().UTC()) {
+		return nil
+	}
+	svc, err := newLinkedInAuthServiceWithConfigPath(configPath)
+	if err != nil {
+		return err
+	}
+	token, err := svc.RefreshAccessToken(context.Background(), profile)
+	if err != nil {
+		return err
+	}
+	if token.AccessTokenExpiresAt.IsZero() || !token.AccessTokenExpiresAt.After(time.Now().UTC()) {
+		return fmt.Errorf("profile token is expired (expires_at=%s)", selected.ExpiresAt)
+	}
+	return nil
+}
+
+func newLinkedInAuthServiceWithConfigPath(configPath string) (*linkedin.Service, error) {
+	return linkedin.NewService(
+		nil,
+		linkedin.DefaultAuthBaseURL,
+		linkedin.DefaultAPIBaseURL,
+		linkedInProfileStore{configPath: configPath},
+		auth.NewSecretStore(),
+	), nil
+}
+
+func parseOptionalRFC3339(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339, raw)
+}
+
+func formatOptionalRFC3339(value time.Time) string {
+	if value.IsZero() {
+		return time.Now().UTC().Add(defaultLinkedInProfileTTL).Format(time.RFC3339)
+	}
+	return value.UTC().Format(time.RFC3339)
+}

--- a/internal/cli/cmd/li_targeting.go
+++ b/internal/cli/cmd/li_targeting.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/bilalbayram/metacli/internal/linkedin"
+	"github.com/spf13/cobra"
+)
+
+func newLITargetingFacetsCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile string
+		version string
+	)
+	cmd := &cobra.Command{
+		Use:   "facets",
+		Short: "List LinkedIn targeting facets. Avoid protected-characteristic targeting and comply with LinkedIn anti-discrimination policies.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting facets", err, linkedInEnvelopeProvider(version))
+			}
+			client, err := newLinkedInClient(creds, resolvedVersion)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting facets", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			rows := make([]map[string]any, 0)
+			paging, err := client.FetchCollection(cmd.Context(), linkedin.Request{
+				Method:  http.MethodGet,
+				Path:    "/rest/adTargetingFacets",
+				Version: resolvedVersion,
+			}, linkedin.PaginationOptions{FollowNext: true}, func(row map[string]any) error {
+				rows = append(rows, row)
+				return nil
+			})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting facets", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li targeting facets", rows, paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	return cmd
+}
+
+func newLITargetingEntitiesCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile string
+		version string
+		facet   string
+	)
+	cmd := &cobra.Command{
+		Use:   "entities",
+		Short: "List targeting entities for a facet. Use only lawful, policy-compliant targeting criteria.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLITargetingFinder(runtime, cmd, "meta li targeting entities", profile, version, map[string]string{
+				"q":     "adTargetingFacet",
+				"facet": strings.TrimSpace(facet),
+			})
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&facet, "facet", "", "Targeting facet URN")
+	mustMarkFlagRequired(cmd, "facet")
+	return cmd
+}
+
+func newLITargetingSearchCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile string
+		version string
+		facet   string
+		query   string
+	)
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Typeahead targeting search. Do not target protected classes or infer sensitive attributes.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(query) == "" {
+				return writeCommandError(cmd, runtime, "meta li targeting search", errors.New("query is required"))
+			}
+			return runLITargetingFinder(runtime, cmd, "meta li targeting search", profile, version, map[string]string{
+				"q":     "typeahead",
+				"facet": strings.TrimSpace(facet),
+				"query": strings.TrimSpace(query),
+			})
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&facet, "facet", "", "Targeting facet URN")
+	cmd.Flags().StringVar(&query, "query", "", "Search string")
+	mustMarkFlagRequired(cmd, "facet")
+	mustMarkFlagRequired(cmd, "query")
+	return cmd
+}
+
+func newLITargetingSimilarCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile string
+		version string
+		facet   string
+		entity  string
+	)
+	cmd := &cobra.Command{
+		Use:   "similar",
+		Short: "List entities similar to a selected targeting entity. Review results for policy compliance before activation.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLITargetingFinder(runtime, cmd, "meta li targeting similar", profile, version, map[string]string{
+				"q":     "similarEntities",
+				"facet": strings.TrimSpace(facet),
+				"urn":   strings.TrimSpace(entity),
+			})
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&facet, "facet", "", "Targeting facet URN")
+	cmd.Flags().StringVar(&entity, "entity-urn", "", "Targeting entity URN")
+	mustMarkFlagRequired(cmd, "facet")
+	mustMarkFlagRequired(cmd, "entity-urn")
+	return cmd
+}
+
+func newLITargetingValidateCommand(runtime Runtime) *cobra.Command {
+	var (
+		profile    string
+		version    string
+		accountURN string
+		facetsRaw  string
+	)
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate a set of targeting facets against a sponsored account. Policy compliance is still your responsibility.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, resolvedVersion, service, err := resolveLIAdsService(runtime, profile, version)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting validate", err, linkedInEnvelopeProvider(version))
+			}
+			account, err := linkedin.NormalizeSponsoredAccountURN(accountURN)
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting validate", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			values := csvToSlice(facetsRaw)
+			if len(values) == 0 {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting validate", errors.New("at least one facet urn is required"), linkedInEnvelopeProvider(resolvedVersion))
+			}
+			urns := make([]linkedin.URN, 0, len(values))
+			for _, value := range values {
+				urn, err := linkedin.NormalizeURN(value, "")
+				if err != nil {
+					return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting validate", err, linkedInEnvelopeProvider(resolvedVersion))
+				}
+				urns = append(urns, urn)
+			}
+			resp, err := service.ValidateTargeting(cmd.Context(), linkedin.TargetingValidateInput{AccountURN: account, FacetURNs: urns})
+			if err != nil {
+				return writeCommandErrorWithProvider(cmd, runtime, "meta li targeting validate", err, linkedInEnvelopeProvider(resolvedVersion))
+			}
+			return writeSuccessWithProvider(cmd, runtime, "meta li targeting validate", resp.Body, nil, nil, linkedInEnvelopeProvider(resolvedVersion))
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "", "LinkedIn profile name")
+	cmd.Flags().StringVar(&version, "version", "", "LinkedIn version header (YYYYMM)")
+	cmd.Flags().StringVar(&accountURN, "account-urn", "", "Sponsored account URN or numeric account id")
+	cmd.Flags().StringVar(&facetsRaw, "facet-urns", "", "Comma-separated targeting facet URNs")
+	mustMarkFlagRequired(cmd, "account-urn")
+	mustMarkFlagRequired(cmd, "facet-urns")
+	return cmd
+}
+
+func runLITargetingFinder(runtime Runtime, cmd *cobra.Command, commandName string, profile string, version string, query map[string]string) error {
+	creds, resolvedVersion, err := resolveLinkedInProfileAndVersion(runtime, profile, version)
+	if err != nil {
+		return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(version))
+	}
+	client, err := newLinkedInClient(creds, resolvedVersion)
+	if err != nil {
+		return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+	}
+	rows := make([]map[string]any, 0)
+	paging, err := client.FetchCollection(cmd.Context(), linkedin.Request{
+		Method:  http.MethodGet,
+		Path:    "/rest/adTargetingEntities",
+		Version: resolvedVersion,
+		Query:   query,
+	}, linkedin.PaginationOptions{FollowNext: true}, func(row map[string]any) error {
+		rows = append(rows, row)
+		return nil
+	})
+	if err != nil {
+		return writeCommandErrorWithProvider(cmd, runtime, commandName, err, linkedInEnvelopeProvider(resolvedVersion))
+	}
+	return writeSuccessWithProvider(cmd, runtime, commandName, rows, paging, nil, linkedInEnvelopeProvider(resolvedVersion))
+}

--- a/internal/cli/cmd/li_test.go
+++ b/internal/cli/cmd/li_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import "testing"
+
+func TestNewLICommandIncludesPublicNamespaces(t *testing.T) {
+	cmd := NewLICommand(Runtime{})
+
+	for _, name := range []string{
+		"auth",
+		"api",
+		"account",
+		"organization",
+		"campaign-group",
+		"campaign",
+		"creative",
+		"insights",
+		"targeting",
+		"lead-form",
+		"lead",
+	} {
+		sub, _, err := cmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("find %s command: %v", name, err)
+		}
+		if sub == nil || sub.Name() != name {
+			t.Fatalf("expected %s command, got %#v", name, sub)
+		}
+	}
+}
+
+func TestNewLIInsightsCommandIncludesNestedNamespaces(t *testing.T) {
+	cmd := NewLICommand(Runtime{})
+
+	for _, args := range [][]string{
+		{"insights", "metrics", "list"},
+		{"insights", "pivots", "list"},
+		{"lead", "webhook", "list"},
+	} {
+		sub, _, err := cmd.Find(args)
+		if err != nil {
+			t.Fatalf("find %v: %v", args, err)
+		}
+		if sub == nil {
+			t.Fatalf("expected command for %v", args)
+		}
+	}
+}

--- a/internal/cli/cmd/output.go
+++ b/internal/cli/cmd/output.go
@@ -5,12 +5,17 @@ import (
 	"fmt"
 
 	"github.com/bilalbayram/metacli/internal/graph"
+	"github.com/bilalbayram/metacli/internal/linkedin"
 	"github.com/bilalbayram/metacli/internal/output"
 	"github.com/spf13/cobra"
 )
 
 func writeSuccess(cmd *cobra.Command, runtime Runtime, commandName string, data any, paging any, rateLimit any) error {
-	envelope, err := output.NewEnvelope(commandName, true, data, paging, rateLimit, nil)
+	return writeSuccessWithProvider(cmd, runtime, commandName, data, paging, rateLimit, nil)
+}
+
+func writeSuccessWithProvider(cmd *cobra.Command, runtime Runtime, commandName string, data any, paging any, rateLimit any, provider *output.Provider) error {
+	envelope, err := output.NewEnvelopeWithProvider(commandName, true, data, paging, rateLimit, nil, provider)
 	if err != nil {
 		return err
 	}
@@ -18,6 +23,10 @@ func writeSuccess(cmd *cobra.Command, runtime Runtime, commandName string, data 
 }
 
 func writeCommandError(cmd *cobra.Command, runtime Runtime, commandName string, err error) error {
+	return writeCommandErrorWithProvider(cmd, runtime, commandName, err, nil)
+}
+
+func writeCommandErrorWithProvider(cmd *cobra.Command, runtime Runtime, commandName string, err error, provider *output.Provider) error {
 	if err == nil {
 		return nil
 	}
@@ -49,8 +58,20 @@ func writeCommandError(cmd *cobra.Command, runtime Runtime, commandName string, 
 			errorInfo.Remediation = mapRemediation(&remediation)
 		}
 	}
+	var linkedInErr *linkedin.APIError
+	if errors.As(err, &linkedInErr) {
+		errorInfo.Type = string(linkedInErr.Category)
+		errorInfo.StatusCode = linkedInErr.StatusCode
+		errorInfo.Message = linkedInErr.Message
+		errorInfo.Retryable = linkedInErr.Retryable
+		errorInfo.Diagnostics = cloneMap(linkedInErr.Diagnostics)
+		errorInfo.Remediation = &output.Remediation{
+			Category: string(linkedInErr.Category),
+			Summary:  linkedInErr.Message,
+		}
+	}
 
-	envelope, envErr := output.NewEnvelope(commandName, false, nil, nil, nil, errorInfo)
+	envelope, envErr := output.NewEnvelopeWithProvider(commandName, false, nil, nil, nil, errorInfo, provider)
 	if envErr != nil {
 		return fmt.Errorf("%w (secondary output error: %v)", err, envErr)
 	}

--- a/internal/cli/cmd/profile.go
+++ b/internal/cli/cmd/profile.go
@@ -12,15 +12,27 @@ import (
 )
 
 var profileAuthPreflight = runProfileAuthPreflight
+var profileLinkedInPreflight = runLinkedInProfileAuthPreflight
 
 type ProfileCredentials struct {
-	Name      string
-	Profile   config.Profile
-	Token     string
-	AppSecret string
+	Name         string
+	Provider     string
+	Profile      config.Profile
+	Token        string
+	AppSecret    string
+	ClientSecret string
+	RefreshToken string
 }
 
 func loadProfileCredentials(profile string) (*ProfileCredentials, error) {
+	return loadProviderProfileCredentials(profile, config.ProviderMeta)
+}
+
+func loadLinkedInProfileCredentials(profile string) (*ProfileCredentials, error) {
+	return loadProviderProfileCredentials(profile, config.ProviderLinkedIn)
+}
+
+func loadProviderProfileCredentials(profile string, expectedProvider string) (*ProfileCredentials, error) {
 	if strings.TrimSpace(profile) == "" {
 		return nil, errors.New("profile is required")
 	}
@@ -37,9 +49,20 @@ func loadProfileCredentials(profile string) (*ProfileCredentials, error) {
 	if err != nil {
 		return nil, err
 	}
+	provider := config.ResolveProvider(selected.Provider)
+	if expectedProvider != "" && provider != expectedProvider {
+		return nil, fmt.Errorf("profile %q uses provider %q, expected %q", name, provider, expectedProvider)
+	}
 
-	if err := profileAuthPreflight(name, selected.Scopes, configPath); err != nil {
-		return nil, fmt.Errorf("auth preflight failed for profile %q: %w", name, err)
+	switch provider {
+	case config.ProviderMeta:
+		if err := profileAuthPreflight(name, selected.Scopes, configPath); err != nil {
+			return nil, fmt.Errorf("auth preflight failed for profile %q: %w", name, err)
+		}
+	case config.ProviderLinkedIn:
+		if err := profileLinkedInPreflight(name, selected, configPath); err != nil {
+			return nil, fmt.Errorf("linkedin auth preflight failed for profile %q: %w", name, err)
+		}
 	}
 
 	store := auth.NewSecretStore()
@@ -48,17 +71,34 @@ func loadProfileCredentials(profile string) (*ProfileCredentials, error) {
 		return nil, err
 	}
 	out := &ProfileCredentials{
-		Name:    name,
-		Profile: selected,
-		Token:   token,
+		Name:     name,
+		Provider: provider,
+		Profile:  selected,
+		Token:    token,
 	}
 
-	if selected.AppSecretRef != "" {
+	if provider == config.ProviderMeta && selected.AppSecretRef != "" {
 		appSecret, err := store.Get(selected.AppSecretRef)
 		if err != nil {
 			return nil, fmt.Errorf("load app secret for profile %q: %w", profile, err)
 		}
 		out.AppSecret = appSecret
+	}
+	if provider == config.ProviderLinkedIn {
+		if selected.ClientSecretRef != "" {
+			clientSecret, err := store.Get(selected.ClientSecretRef)
+			if err != nil {
+				return nil, fmt.Errorf("load client secret for profile %q: %w", profile, err)
+			}
+			out.ClientSecret = clientSecret
+		}
+		if selected.RefreshTokenRef != "" {
+			refreshToken, err := store.Get(selected.RefreshTokenRef)
+			if err != nil {
+				return nil, fmt.Errorf("load refresh token for profile %q: %w", profile, err)
+			}
+			out.RefreshToken = refreshToken
+		}
 	}
 	return out, nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -64,6 +64,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(command.NewSchemaCommand(runtime))
 	cmd.AddCommand(command.NewDoctorCommand(runtime))
 	cmd.AddCommand(command.NewChangelogCommand(runtime))
+	cmd.AddCommand(command.NewLICommand(runtime))
 	cmd.AddCommand(command.NewIGCommand(runtime))
 	cmd.AddCommand(command.NewWACommand(runtime))
 	cmd.AddCommand(command.NewMSGRCommand(runtime))

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -65,6 +65,12 @@ func TestSubcommandRequiredErrorsPrintHelp(t *testing.T) {
 		usagePrefix string
 	}{
 		{
+			name:        "li",
+			args:        []string{"li"},
+			errorString: "li requires a subcommand",
+			usagePrefix: "meta li",
+		},
+		{
 			name:        "ig",
 			args:        []string{"ig"},
 			errorString: "ig requires a subcommand",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,28 +8,37 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	SchemaVersion       = 2
-	DefaultGraphVersion = "v25.0"
-	DefaultDomain       = "marketing"
+	SchemaVersion          = 2
+	ProviderMeta           = "meta"
+	ProviderLinkedIn       = "linkedin"
+	DefaultGraphVersion    = "v25.0"
+	DefaultLinkedInVersion = "202601"
+	DefaultDomain          = "marketing"
 )
 
 type Profile struct {
+	Provider        string   `yaml:"provider,omitempty"`
 	Domain          string   `yaml:"domain"`
-	GraphVersion    string   `yaml:"graph_version"`
-	TokenType       string   `yaml:"token_type"`
+	GraphVersion    string   `yaml:"graph_version,omitempty"`
+	LinkedInVersion string   `yaml:"linkedin_version,omitempty"`
+	TokenType       string   `yaml:"token_type,omitempty"`
 	BusinessID      string   `yaml:"business_id,omitempty"`
 	AppID           string   `yaml:"app_id,omitempty"`
+	ClientID        string   `yaml:"client_id,omitempty"`
 	PageID          string   `yaml:"page_id,omitempty"`
 	SourceProfile   string   `yaml:"source_profile,omitempty"`
 	TokenRef        string   `yaml:"token_ref"`
 	AppSecretRef    string   `yaml:"app_secret_ref,omitempty"`
-	AuthProvider    string   `yaml:"auth_provider"`
-	AuthMode        string   `yaml:"auth_mode"`
+	ClientSecretRef string   `yaml:"client_secret_ref,omitempty"`
+	RefreshTokenRef string   `yaml:"refresh_token_ref,omitempty"`
+	AuthProvider    string   `yaml:"auth_provider,omitempty"`
+	AuthMode        string   `yaml:"auth_mode,omitempty"`
 	Scopes          []string `yaml:"scopes"`
 	IssuedAt        string   `yaml:"issued_at"`
 	ExpiresAt       string   `yaml:"expires_at"`
@@ -195,10 +204,17 @@ func (c *Config) UpsertProfile(name string, profile Profile) error {
 }
 
 func applyProfileDefaults(profile Profile) Profile {
+	if profile.Provider == "" {
+		profile.Provider = ProviderMeta
+	}
 	if profile.Domain == "" {
 		profile.Domain = DefaultDomain
 	}
-	if profile.GraphVersion == "" {
+	if profile.Provider == ProviderLinkedIn {
+		if profile.LinkedInVersion == "" {
+			profile.LinkedInVersion = DefaultLinkedInVersion
+		}
+	} else if profile.GraphVersion == "" {
 		profile.GraphVersion = DefaultGraphVersion
 	}
 	return profile
@@ -208,44 +224,68 @@ func validateProfile(name string, profile Profile) error {
 	if name == "" {
 		return errors.New("profile name cannot be empty")
 	}
+	provider := ResolveProvider(profile.Provider)
+	if provider == "" {
+		return fmt.Errorf("profile %q provider must be one of [%s %s]", name, ProviderMeta, ProviderLinkedIn)
+	}
 	if profile.Domain == "" {
 		return fmt.Errorf("profile %q domain is required", name)
-	}
-	if profile.GraphVersion == "" {
-		return fmt.Errorf("profile %q graph_version is required", name)
-	}
-	if profile.TokenType == "" {
-		return fmt.Errorf("profile %q token_type is required", name)
-	}
-	switch profile.TokenType {
-	case "system_user", "user", "page", "app":
-	default:
-		return fmt.Errorf("profile %q token_type must be one of [system_user user page app]", name)
 	}
 	if profile.TokenRef == "" {
 		return fmt.Errorf("profile %q token_ref is required", name)
 	}
-	if profile.AppID == "" {
-		return fmt.Errorf("profile %q app_id is required", name)
-	}
-	if profile.AppSecretRef == "" {
-		return fmt.Errorf("profile %q app_secret_ref is required", name)
-	}
-	if profile.AuthProvider == "" {
-		return fmt.Errorf("profile %q auth_provider is required", name)
-	}
-	switch profile.AuthProvider {
-	case "facebook_login", "instagram_login", "system_user", "app":
-	default:
-		return fmt.Errorf("profile %q auth_provider must be one of [facebook_login instagram_login system_user app]", name)
-	}
-	if profile.AuthMode == "" {
-		return fmt.Errorf("profile %q auth_mode is required", name)
-	}
-	switch profile.AuthMode {
-	case "both", "facebook", "instagram":
-	default:
-		return fmt.Errorf("profile %q auth_mode must be one of [both facebook instagram]", name)
+
+	switch provider {
+	case ProviderMeta:
+		if profile.GraphVersion == "" {
+			return fmt.Errorf("profile %q graph_version is required", name)
+		}
+		if profile.TokenType == "" {
+			return fmt.Errorf("profile %q token_type is required", name)
+		}
+		switch profile.TokenType {
+		case "system_user", "user", "page", "app":
+		default:
+			return fmt.Errorf("profile %q token_type must be one of [system_user user page app]", name)
+		}
+		if profile.AppID == "" {
+			return fmt.Errorf("profile %q app_id is required", name)
+		}
+		if profile.AppSecretRef == "" {
+			return fmt.Errorf("profile %q app_secret_ref is required", name)
+		}
+		if profile.AuthProvider == "" {
+			return fmt.Errorf("profile %q auth_provider is required", name)
+		}
+		switch profile.AuthProvider {
+		case "facebook_login", "instagram_login", "system_user", "app":
+		default:
+			return fmt.Errorf("profile %q auth_provider must be one of [facebook_login instagram_login system_user app]", name)
+		}
+		if profile.AuthMode == "" {
+			return fmt.Errorf("profile %q auth_mode is required", name)
+		}
+		switch profile.AuthMode {
+		case "both", "facebook", "instagram":
+		default:
+			return fmt.Errorf("profile %q auth_mode must be one of [both facebook instagram]", name)
+		}
+	case ProviderLinkedIn:
+		if profile.LinkedInVersion == "" {
+			return fmt.Errorf("profile %q linkedin_version is required", name)
+		}
+		if len(profile.LinkedInVersion) != 6 || !isDigits(profile.LinkedInVersion) {
+			return fmt.Errorf("profile %q linkedin_version must use YYYYMM format", name)
+		}
+		if profile.ClientID == "" {
+			return fmt.Errorf("profile %q client_id is required", name)
+		}
+		if profile.ClientSecretRef == "" {
+			return fmt.Errorf("profile %q client_secret_ref is required", name)
+		}
+		if profile.RefreshTokenRef == "" {
+			return fmt.Errorf("profile %q refresh_token_ref is required", name)
+		}
 	}
 	if len(profile.Scopes) == 0 {
 		return fmt.Errorf("profile %q scopes must contain at least one scope", name)
@@ -270,4 +310,24 @@ func validateProfile(name string, profile Profile) error {
 		return fmt.Errorf("profile %q last_validated_at must be RFC3339: %w", name, err)
 	}
 	return nil
+}
+
+func ResolveProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", ProviderMeta:
+		return ProviderMeta
+	case ProviderLinkedIn:
+		return ProviderLinkedIn
+	default:
+		return ""
+	}
+}
+
+func isDigits(value string) bool {
+	for _, r := range value {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return value != ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 
 func validProfile() Profile {
 	return Profile{
+		Provider:        ProviderMeta,
 		Domain:          "marketing",
 		GraphVersion:    "v25.0",
 		TokenType:       "system_user",
@@ -22,6 +23,22 @@ func validProfile() Profile {
 		ExpiresAt:       "2026-12-31T00:00:00Z",
 		LastValidatedAt: "2026-01-15T00:00:00Z",
 		IGUserID:        "17841400000000000",
+	}
+}
+
+func validLinkedInProfile() Profile {
+	return Profile{
+		Provider:        ProviderLinkedIn,
+		Domain:          "marketing",
+		LinkedInVersion: DefaultLinkedInVersion,
+		ClientID:        "client-123",
+		TokenRef:        "keychain://meta-marketing-cli/prod/token",
+		ClientSecretRef: "keychain://meta-marketing-cli/prod/client_secret",
+		RefreshTokenRef: "keychain://meta-marketing-cli/prod/refresh_token",
+		Scopes:          []string{"r_ads", "rw_ads"},
+		IssuedAt:        "2026-01-01T00:00:00Z",
+		ExpiresAt:       "2026-12-31T00:00:00Z",
+		LastValidatedAt: "2026-01-15T00:00:00Z",
 	}
 }
 
@@ -53,6 +70,9 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	}
 	if loaded.Profiles["prod"].TokenRef != "keychain://meta-marketing-cli/prod/token" {
 		t.Fatalf("unexpected token ref: %s", loaded.Profiles["prod"].TokenRef)
+	}
+	if loaded.Profiles["prod"].Provider != ProviderMeta {
+		t.Fatalf("unexpected provider: %s", loaded.Profiles["prod"].Provider)
 	}
 }
 
@@ -298,6 +318,88 @@ func TestUpsertProfileAllowsSupportedTokenTypes(t *testing.T) {
 
 			if err := cfg.UpsertProfile("prod", profile); err != nil {
 				t.Fatalf("upsert profile for token_type=%s: %v", tokenType, err)
+			}
+		})
+	}
+}
+
+func TestUpsertProfileDefaultsBlankProviderToMeta(t *testing.T) {
+	t.Parallel()
+
+	cfg := New()
+	profile := validProfile()
+	profile.Provider = ""
+
+	if err := cfg.UpsertProfile("prod", profile); err != nil {
+		t.Fatalf("upsert profile: %v", err)
+	}
+	if got := cfg.Profiles["prod"].Provider; got != ProviderMeta {
+		t.Fatalf("unexpected provider default: %q", got)
+	}
+}
+
+func TestUpsertProfileAllowsLinkedInProfiles(t *testing.T) {
+	t.Parallel()
+
+	cfg := New()
+	if err := cfg.UpsertProfile("li-prod", validLinkedInProfile()); err != nil {
+		t.Fatalf("upsert linkedin profile: %v", err)
+	}
+}
+
+func TestUpsertLinkedInProfileValidationFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mutate   func(*Profile)
+		wantText string
+	}{
+		{
+			name: "linkedin version format",
+			mutate: func(p *Profile) {
+				p.LinkedInVersion = "2026-01"
+			},
+			wantText: "linkedin_version must use YYYYMM format",
+		},
+		{
+			name: "client id required",
+			mutate: func(p *Profile) {
+				p.ClientID = ""
+			},
+			wantText: "client_id is required",
+		},
+		{
+			name: "client secret ref required",
+			mutate: func(p *Profile) {
+				p.ClientSecretRef = ""
+			},
+			wantText: "client_secret_ref is required",
+		},
+		{
+			name: "refresh token ref required",
+			mutate: func(p *Profile) {
+				p.RefreshTokenRef = ""
+			},
+			wantText: "refresh_token_ref is required",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := New()
+			profile := validLinkedInProfile()
+			tc.mutate(&profile)
+
+			err := cfg.UpsertProfile("li-prod", profile)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/internal/linkedin/ads.go
+++ b/internal/linkedin/ads.go
@@ -77,17 +77,41 @@ func (s *AdsService) ListAccountRoles(ctx context.Context, accountURN URN, pageS
 	if err != nil {
 		return nil, err
 	}
-	if pageSize > 0 {
-		return nil, errors.New("account role pagination is not supported by LinkedIn adAccountUsers?q=accounts")
+	values, err := offsetPagedValues(pageSize, pageToken)
+	if err != nil {
+		return nil, err
 	}
-	if strings.TrimSpace(pageToken) != "" {
-		return nil, errors.New("account role pagination is not supported by LinkedIn adAccountUsers?q=accounts")
+	startToken := values[DefaultOffsetStartParam]
+	values["q"] = "accounts"
+	values["accounts"] = normalized.String()
+	result, err := s.listCollectionWithOptions(ctx, pathAdAccountUsers, values, nil, PaginationOptions{
+		FollowNext:     true,
+		PageSize:       pageSize,
+		PageToken:      startToken,
+		PageSizeParam:  DefaultOffsetCountParam,
+		PageTokenParam: DefaultOffsetStartParam,
+	})
+	if err == nil || !shouldFallbackAccountRoles(err) {
+		return result, err
 	}
-	values := map[string]string{
-		"q":        "accounts",
-		"accounts": normalized.String(),
+	fallbackValues, err := offsetPagedValues(pageSize, pageToken)
+	if err != nil {
+		return nil, err
 	}
-	return s.listCollection(ctx, pathAdAccountUsers, values)
+	fallbackStartToken := fallbackValues[DefaultOffsetStartParam]
+	fallbackValues["q"] = "authenticatedUser"
+	result, err = s.listCollectionWithOptions(ctx, pathAdAccountUsers, fallbackValues, nil, PaginationOptions{
+		FollowNext:     true,
+		PageSize:       pageSize,
+		PageToken:      fallbackStartToken,
+		PageSizeParam:  DefaultOffsetCountParam,
+		PageTokenParam: DefaultOffsetStartParam,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Elements = filterAccountRoleElements(result.Elements, normalized)
+	return result, nil
 }
 
 func (s *AdsService) ListOrganizationRoles(ctx context.Context, organizationURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
@@ -217,10 +241,20 @@ func (s *AdsService) ValidateTargeting(ctx context.Context, input TargetingValid
 }
 
 func (s *AdsService) listCollection(ctx context.Context, path string, query map[string]string) (*CollectionResult, error) {
-	return s.listCollectionWithHeaders(ctx, path, query, nil)
+	return s.listCollectionWithOptions(ctx, path, query, nil, PaginationOptions{
+		FollowNext: true,
+		PageSize:   queryPageSize(query),
+	})
 }
 
 func (s *AdsService) listCollectionWithHeaders(ctx context.Context, path string, query map[string]string, headers map[string]string) (*CollectionResult, error) {
+	return s.listCollectionWithOptions(ctx, path, query, headers, PaginationOptions{
+		FollowNext: true,
+		PageSize:   queryPageSize(query),
+	})
+}
+
+func (s *AdsService) listCollectionWithOptions(ctx context.Context, path string, query map[string]string, headers map[string]string, opts PaginationOptions) (*CollectionResult, error) {
 	if s == nil || s.Client == nil {
 		return nil, errors.New("ads client is required")
 	}
@@ -231,10 +265,7 @@ func (s *AdsService) listCollectionWithHeaders(ctx context.Context, path string,
 		Version: s.clientVersion(),
 		Query:   query,
 		Headers: headers,
-	}, PaginationOptions{
-		FollowNext: true,
-		PageSize:   queryPageSize(query),
-	}, func(element map[string]any) error {
+	}, opts, func(element map[string]any) error {
 		result.Elements = append(result.Elements, element)
 		return nil
 	})
@@ -329,4 +360,48 @@ func queryPageSize(values map[string]string) int {
 	}
 	size, _ := strconv.Atoi(strings.TrimSpace(values[DefaultPageSizeParam]))
 	return size
+}
+
+func offsetPagedValues(pageSize int, pageToken string) (map[string]string, error) {
+	values := map[string]string{}
+	if pageSize > 0 {
+		values[DefaultOffsetCountParam] = fmt.Sprintf("%d", pageSize)
+	}
+	startToken, err := normalizeOffsetToken(pageToken)
+	if err != nil {
+		return nil, err
+	}
+	if startToken != "" {
+		values[DefaultOffsetStartParam] = startToken
+	}
+	return values, nil
+}
+
+func shouldFallbackAccountRoles(err error) bool {
+	apiErr := &Error{}
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.StatusCode != http.StatusBadRequest || apiErr.Category != ErrorCategoryValidation {
+		return false
+	}
+	normalized := strings.ToUpper(strings.TrimSpace(apiErr.Message))
+	if strings.Contains(normalized, "INVALID QUERY PARAMETERS") || strings.Contains(normalized, "QUERY PARAM") {
+		return true
+	}
+	diag := strings.ToUpper(string(mustMarshalLoose(apiErr.Diagnostics)))
+	return strings.Contains(diag, "QUERY_PARAM") || strings.Contains(diag, "FINDER")
+}
+
+func filterAccountRoleElements(elements []map[string]any, accountURN URN) []map[string]any {
+	filtered := make([]map[string]any, 0, len(elements))
+	want := strings.TrimSpace(accountURN.String())
+	for _, element := range elements {
+		account, _ := element["account"].(string)
+		if strings.TrimSpace(account) != want {
+			continue
+		}
+		filtered = append(filtered, element)
+	}
+	return filtered
 }

--- a/internal/linkedin/ads.go
+++ b/internal/linkedin/ads.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	pathAdAccounts                 = "/rest/adAccounts"
+	pathAdAccountUsers             = "/rest/adAccountUsers"
 	pathOrganizations              = "/rest/organizations"
 	pathOrganizationAuthorizations = "/rest/organizationAuthorizations"
 	pathCampaignGroups             = "/rest/adCampaignGroups"
@@ -19,6 +20,28 @@ const (
 	pathLeadForms                  = "/rest/leadForms"
 	pathLeads                      = "/rest/leadFormResponses"
 	pathTargetingFacets            = "/rest/adTargetingFacets"
+)
+
+var (
+	defaultCampaignGroupStatuses = []string{
+		"ACTIVE",
+		"ARCHIVED",
+		"CANCELED",
+		"DRAFT",
+		"PAUSED",
+		"PENDING_DELETION",
+		"REMOVED",
+	}
+	defaultCampaignStatuses = []string{
+		"ACTIVE",
+		"ARCHIVED",
+		"CANCELED",
+		"COMPLETED",
+		"DRAFT",
+		"PAUSED",
+		"PENDING_DELETION",
+		"REMOVED",
+	}
 )
 
 type AdsService struct {
@@ -50,20 +73,21 @@ func (s *AdsService) ListOrganizations(ctx context.Context, search string, pageS
 }
 
 func (s *AdsService) ListAccountRoles(ctx context.Context, accountURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
-	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+	normalized, err := NormalizeSponsoredAccountURN(accountURN.String())
+	if err != nil {
 		return nil, err
 	}
-	values := map[string]string{
-		"q":       "search",
-		"account": accountURN.String(),
-	}
 	if pageSize > 0 {
-		values[DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+		return nil, errors.New("account role pagination is not supported by LinkedIn adAccountUsers?q=accounts")
 	}
 	if strings.TrimSpace(pageToken) != "" {
-		values[DefaultPageTokenParam] = pageToken
+		return nil, errors.New("account role pagination is not supported by LinkedIn adAccountUsers?q=accounts")
 	}
-	return s.listCollection(ctx, pathOrganizationAuthorizations, values)
+	values := map[string]string{
+		"q":        "accounts",
+		"accounts": normalized.String(),
+	}
+	return s.listCollection(ctx, pathAdAccountUsers, values)
 }
 
 func (s *AdsService) ListOrganizationRoles(ctx context.Context, organizationURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
@@ -84,30 +108,31 @@ func (s *AdsService) ListOrganizationRoles(ctx context.Context, organizationURN 
 }
 
 func (s *AdsService) ListCampaignGroups(ctx context.Context, accountURN URN, search string, pageSize int, pageToken string) (*CollectionResult, error) {
-	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+	resourcePath, err := accountResourcePath(accountURN, "adCampaignGroups")
+	if err != nil {
 		return nil, err
 	}
-	values := valuesWithSearch(search, pageSize, pageToken)
-	values["account"] = accountURN.String()
-	return s.listCollection(ctx, pathCampaignGroups, values)
+	return s.listCollection(ctx, resourcePath, valuesWithCampaignSearch(search, pageSize, pageToken, defaultCampaignGroupStatuses))
 }
 
 func (s *AdsService) ListCampaigns(ctx context.Context, accountURN URN, search string, pageSize int, pageToken string) (*CollectionResult, error) {
-	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+	resourcePath, err := accountResourcePath(accountURN, "adCampaigns")
+	if err != nil {
 		return nil, err
 	}
-	values := valuesWithSearch(search, pageSize, pageToken)
-	values["account"] = accountURN.String()
-	return s.listCollection(ctx, pathCampaigns, values)
+	return s.listCollection(ctx, resourcePath, valuesWithCampaignSearch(search, pageSize, pageToken, defaultCampaignStatuses))
 }
 
 func (s *AdsService) ListCreatives(ctx context.Context, accountURN URN, search string, pageSize int, pageToken string) (*CollectionResult, error) {
-	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+	resourcePath, err := accountResourcePath(accountURN, "creatives")
+	if err != nil {
 		return nil, err
 	}
-	values := valuesWithSearch(search, pageSize, pageToken)
-	values["account"] = accountURN.String()
-	return s.listCollection(ctx, pathCreatives, values)
+	values, err := creativeListValues(search, pageSize, pageToken)
+	if err != nil {
+		return nil, err
+	}
+	return s.listCollectionWithHeaders(ctx, resourcePath, values, map[string]string{"X-RestLi-Method": "FINDER"})
 }
 
 func (s *AdsService) ListLeadForms(ctx context.Context, accountURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
@@ -192,6 +217,10 @@ func (s *AdsService) ValidateTargeting(ctx context.Context, input TargetingValid
 }
 
 func (s *AdsService) listCollection(ctx context.Context, path string, query map[string]string) (*CollectionResult, error) {
+	return s.listCollectionWithHeaders(ctx, path, query, nil)
+}
+
+func (s *AdsService) listCollectionWithHeaders(ctx context.Context, path string, query map[string]string, headers map[string]string) (*CollectionResult, error) {
 	if s == nil || s.Client == nil {
 		return nil, errors.New("ads client is required")
 	}
@@ -201,6 +230,7 @@ func (s *AdsService) listCollection(ctx context.Context, path string, query map[
 		Path:    path,
 		Version: s.clientVersion(),
 		Query:   query,
+		Headers: headers,
 	}, PaginationOptions{
 		FollowNext: true,
 		PageSize:   queryPageSize(query),
@@ -234,6 +264,63 @@ func valuesWithSearch(search string, pageSize int, pageToken string) map[string]
 		values[DefaultPageTokenParam] = pageToken
 	}
 	return values
+}
+
+func valuesWithCampaignSearch(search string, pageSize int, pageToken string, defaultStatuses []string) map[string]string {
+	values := pagedValues(pageSize, pageToken)
+	values["q"] = "search"
+	values["search"] = namedSearchExpression(search, defaultStatuses)
+	return values
+}
+
+func creativeListValues(search string, pageSize int, pageToken string) (map[string]string, error) {
+	values := pagedValues(pageSize, pageToken)
+	values["q"] = "criteria"
+	values["sortOrder"] = "ASCENDING"
+	search = strings.TrimSpace(search)
+	if search == "" {
+		return values, nil
+	}
+	return nil, errors.New("creative search currently supports only LinkedIn criteria finder inputs via meta li api; omit --search for full account listing")
+}
+
+func pagedValues(pageSize int, pageToken string) map[string]string {
+	values := map[string]string{}
+	if pageSize > 0 {
+		values[DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+	}
+	if strings.TrimSpace(pageToken) != "" {
+		values[DefaultPageTokenParam] = strings.TrimSpace(pageToken)
+	}
+	return values
+}
+
+func namedSearchExpression(search string, defaultStatuses []string) string {
+	search = strings.TrimSpace(search)
+	switch {
+	case search == "":
+		return searchExpression("status", defaultStatuses...)
+	case strings.HasPrefix(search, "("):
+		return search
+	default:
+		return searchExpression("name", search)
+	}
+}
+
+func searchExpression(field string, values ...string) string {
+	return fmt.Sprintf("(%s:(values:%s))", strings.TrimSpace(field), listValue(values...))
+}
+
+func accountResourcePath(accountURN URN, resource string) (string, error) {
+	normalized, err := NormalizeSponsoredAccountURN(accountURN.String())
+	if err != nil {
+		return "", err
+	}
+	_, _, id, err := ParseURN(normalized.String())
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%s/%s", pathAdAccounts, id, strings.TrimPrefix(strings.TrimSpace(resource), "/")), nil
 }
 
 func queryPageSize(values map[string]string) int {

--- a/internal/linkedin/ads.go
+++ b/internal/linkedin/ads.go
@@ -1,0 +1,245 @@
+package linkedin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	pathAdAccounts                 = "/rest/adAccounts"
+	pathOrganizations              = "/rest/organizations"
+	pathOrganizationAuthorizations = "/rest/organizationAuthorizations"
+	pathCampaignGroups             = "/rest/adCampaignGroups"
+	pathCampaigns                  = "/rest/adCampaigns"
+	pathCreatives                  = "/rest/creatives"
+	pathLeadForms                  = "/rest/leadForms"
+	pathLeads                      = "/rest/leadFormResponses"
+	pathTargetingFacets            = "/rest/adTargetingFacets"
+)
+
+type AdsService struct {
+	Client *Client
+}
+
+type TargetingSearchInput struct {
+	AccountURN URN
+	Query      string
+	PageSize   int
+	PageToken  string
+}
+
+type TargetingValidateInput struct {
+	AccountURN URN
+	FacetURNs  []URN
+}
+
+func NewAdsService(client *Client) *AdsService {
+	return &AdsService{Client: client}
+}
+
+func (s *AdsService) ListAdAccounts(ctx context.Context, search string, pageSize int, pageToken string) (*CollectionResult, error) {
+	return s.listCollection(ctx, pathAdAccounts, valuesWithSearch(search, pageSize, pageToken))
+}
+
+func (s *AdsService) ListOrganizations(ctx context.Context, search string, pageSize int, pageToken string) (*CollectionResult, error) {
+	return s.listCollection(ctx, pathOrganizations, valuesWithSearch(search, pageSize, pageToken))
+}
+
+func (s *AdsService) ListAccountRoles(ctx context.Context, accountURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
+	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+		return nil, err
+	}
+	values := map[string]string{
+		"q":       "search",
+		"account": accountURN.String(),
+	}
+	if pageSize > 0 {
+		values[DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+	}
+	if strings.TrimSpace(pageToken) != "" {
+		values[DefaultPageTokenParam] = pageToken
+	}
+	return s.listCollection(ctx, pathOrganizationAuthorizations, values)
+}
+
+func (s *AdsService) ListOrganizationRoles(ctx context.Context, organizationURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
+	if _, err := NormalizeOrganizationURN(organizationURN.String()); err != nil {
+		return nil, err
+	}
+	values := map[string]string{
+		"q":            "search",
+		"organization": organizationURN.String(),
+	}
+	if pageSize > 0 {
+		values[DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+	}
+	if strings.TrimSpace(pageToken) != "" {
+		values[DefaultPageTokenParam] = pageToken
+	}
+	return s.listCollection(ctx, pathOrganizationAuthorizations, values)
+}
+
+func (s *AdsService) ListCampaignGroups(ctx context.Context, accountURN URN, search string, pageSize int, pageToken string) (*CollectionResult, error) {
+	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+		return nil, err
+	}
+	values := valuesWithSearch(search, pageSize, pageToken)
+	values["account"] = accountURN.String()
+	return s.listCollection(ctx, pathCampaignGroups, values)
+}
+
+func (s *AdsService) ListCampaigns(ctx context.Context, accountURN URN, search string, pageSize int, pageToken string) (*CollectionResult, error) {
+	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+		return nil, err
+	}
+	values := valuesWithSearch(search, pageSize, pageToken)
+	values["account"] = accountURN.String()
+	return s.listCollection(ctx, pathCampaigns, values)
+}
+
+func (s *AdsService) ListCreatives(ctx context.Context, accountURN URN, search string, pageSize int, pageToken string) (*CollectionResult, error) {
+	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+		return nil, err
+	}
+	values := valuesWithSearch(search, pageSize, pageToken)
+	values["account"] = accountURN.String()
+	return s.listCollection(ctx, pathCreatives, values)
+}
+
+func (s *AdsService) ListLeadForms(ctx context.Context, accountURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
+	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+		return nil, err
+	}
+	values := map[string]string{
+		"q":       "search",
+		"account": accountURN.String(),
+	}
+	if pageSize > 0 {
+		values[DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+	}
+	if strings.TrimSpace(pageToken) != "" {
+		values[DefaultPageTokenParam] = pageToken
+	}
+	return s.listCollection(ctx, pathLeadForms, values)
+}
+
+func (s *AdsService) ListLeads(ctx context.Context, accountURN URN, pageSize int, pageToken string) (*CollectionResult, error) {
+	if _, err := NormalizeSponsoredAccountURN(accountURN.String()); err != nil {
+		return nil, err
+	}
+	values := map[string]string{
+		"q":       "search",
+		"account": accountURN.String(),
+	}
+	if pageSize > 0 {
+		values[DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+	}
+	if strings.TrimSpace(pageToken) != "" {
+		values[DefaultPageTokenParam] = pageToken
+	}
+	return s.listCollection(ctx, pathLeads, values)
+}
+
+func (s *AdsService) SearchTargeting(ctx context.Context, input TargetingSearchInput) (*CollectionResult, error) {
+	if strings.TrimSpace(input.Query) == "" {
+		return nil, errors.New("targeting search query is required")
+	}
+	if _, err := NormalizeSponsoredAccountURN(input.AccountURN.String()); err != nil {
+		return nil, err
+	}
+	values := map[string]string{
+		"q":       "search",
+		"account": input.AccountURN.String(),
+		"query":   strings.TrimSpace(input.Query),
+	}
+	if input.PageSize > 0 {
+		values[DefaultPageSizeParam] = fmt.Sprintf("%d", input.PageSize)
+	}
+	if strings.TrimSpace(input.PageToken) != "" {
+		values[DefaultPageTokenParam] = input.PageToken
+	}
+	return s.listCollection(ctx, pathTargetingFacets, values)
+}
+
+func (s *AdsService) ValidateTargeting(ctx context.Context, input TargetingValidateInput) (*Response, error) {
+	if _, err := NormalizeSponsoredAccountURN(input.AccountURN.String()); err != nil {
+		return nil, err
+	}
+	if len(input.FacetURNs) == 0 {
+		return nil, errors.New("at least one targeting facet urn is required")
+	}
+	facets := make([]string, 0, len(input.FacetURNs))
+	for _, facet := range input.FacetURNs {
+		if strings.TrimSpace(facet.String()) == "" {
+			return nil, errors.New("targeting facet urn is required")
+		}
+		facets = append(facets, facet.String())
+	}
+	body := map[string]any{
+		"account": input.AccountURN.String(),
+		"facets":  facets,
+	}
+	return s.Client.Do(ctx, Request{
+		Method:   http.MethodPost,
+		Path:     pathTargetingFacets + "/validate",
+		Version:  s.clientVersion(),
+		JSONBody: body,
+	})
+}
+
+func (s *AdsService) listCollection(ctx context.Context, path string, query map[string]string) (*CollectionResult, error) {
+	if s == nil || s.Client == nil {
+		return nil, errors.New("ads client is required")
+	}
+	result := &CollectionResult{Elements: make([]map[string]any, 0)}
+	paging, err := s.Client.FetchCollection(ctx, Request{
+		Method:  http.MethodGet,
+		Path:    path,
+		Version: s.clientVersion(),
+		Query:   query,
+	}, PaginationOptions{
+		FollowNext: true,
+		PageSize:   queryPageSize(query),
+	}, func(element map[string]any) error {
+		result.Elements = append(result.Elements, element)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Paging = paging
+	return result, nil
+}
+
+func (s *AdsService) clientVersion() string {
+	if s == nil || s.Client == nil {
+		return ""
+	}
+	return s.Client.Version
+}
+
+func valuesWithSearch(search string, pageSize int, pageToken string) map[string]string {
+	values := map[string]string{"q": "search"}
+	if strings.TrimSpace(search) != "" {
+		values["search"] = strings.TrimSpace(search)
+	}
+	if pageSize > 0 {
+		values[DefaultPageSizeParam] = fmt.Sprintf("%d", pageSize)
+	}
+	if strings.TrimSpace(pageToken) != "" {
+		values[DefaultPageTokenParam] = pageToken
+	}
+	return values
+}
+
+func queryPageSize(values map[string]string) int {
+	if values == nil {
+		return 0
+	}
+	size, _ := strconv.Atoi(strings.TrimSpace(values[DefaultPageSizeParam]))
+	return size
+}

--- a/internal/linkedin/ads_test.go
+++ b/internal/linkedin/ads_test.go
@@ -1,0 +1,126 @@
+package linkedin
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestListCampaignsBuildsExpectedRequest(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"id":"1"}],"paging":{"count":1}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := NewAdsService(client)
+
+	accountURN, err := SponsoredAccountURN("123")
+	if err != nil {
+		t.Fatalf("account urn: %v", err)
+	}
+	result, err := service.ListCampaigns(context.Background(), accountURN, "spring", 25, "abc")
+	if err != nil {
+		t.Fatalf("list campaigns: %v", err)
+	}
+	if len(result.Elements) != 1 {
+		t.Fatalf("unexpected result %#v", result)
+	}
+
+	req := httpClient.requests[0]
+	if got := req.URL.Path; got != "/rest/adCampaigns" {
+		t.Fatalf("unexpected path %q", got)
+	}
+	query := req.URL.Query()
+	if got := query.Get("q"); got != "search" {
+		t.Fatalf("unexpected q %q", got)
+	}
+	if got := query.Get("account"); got != accountURN.String() {
+		t.Fatalf("unexpected account %q", got)
+	}
+	if got := query.Get("search"); got != "spring" {
+		t.Fatalf("unexpected search %q", got)
+	}
+	if got := query.Get("pageSize"); got != "25" {
+		t.Fatalf("unexpected pageSize %q", got)
+	}
+	if got := query.Get("pageToken"); got != "abc" {
+		t.Fatalf("unexpected pageToken %q", got)
+	}
+}
+
+func TestValidateTargetingRejectsMissingFacets(t *testing.T) {
+	service := NewAdsService(NewClient(nil, "", "202402", "token"))
+	accountURN, _ := SponsoredAccountURN("123")
+	_, err := service.ValidateTargeting(context.Background(), TargetingValidateInput{
+		AccountURN: accountURN,
+		FacetURNs:  nil,
+	})
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("expected facet validation failure, got %v", err)
+	}
+}
+
+func TestSearchTargetingRejectsBlankQuery(t *testing.T) {
+	service := NewAdsService(NewClient(nil, "", "202402", "token"))
+	accountURN, _ := SponsoredAccountURN("123")
+	_, err := service.SearchTargeting(context.Background(), TargetingSearchInput{
+		AccountURN: accountURN,
+		Query:      " ",
+	})
+	if err == nil {
+		t.Fatal("expected blank query failure")
+	}
+}
+
+func TestNormalizeURNHelpers(t *testing.T) {
+	urn, err := NormalizeSponsoredCampaignURN("456")
+	if err != nil {
+		t.Fatalf("normalize campaign urn: %v", err)
+	}
+	if got := urn.String(); got != "urn:li:adCampaign:456" {
+		t.Fatalf("unexpected urn %q", got)
+	}
+}
+
+func TestListAdAccountsBuildsSearchRequest(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"id":"1"}],"paging":{"count":1}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := NewAdsService(client)
+
+	if _, err := service.ListAdAccounts(context.Background(), "display", 10, "token"); err != nil {
+		t.Fatalf("list accounts: %v", err)
+	}
+	req := httpClient.requests[0]
+	if got := req.URL.Query().Get("search"); got != "display" {
+		t.Fatalf("unexpected search %q", got)
+	}
+	if got := req.URL.Query().Get("pageSize"); got != "10" {
+		t.Fatalf("unexpected pageSize %q", got)
+	}
+}
+
+func TestValuesWithSearchTrimAndEncode(t *testing.T) {
+	values := valuesWithSearch(" spring ", 5, "abc")
+	if got := values["search"]; got != "spring" {
+		t.Fatalf("unexpected search %q", got)
+	}
+	if got := values["pageToken"]; got != "abc" {
+		t.Fatalf("unexpected page token %q", got)
+	}
+}
+
+func TestListLeadFormsRequiresAccountURN(t *testing.T) {
+	service := NewAdsService(NewClient(nil, "", "202402", "token"))
+	_, err := service.ListLeadForms(context.Background(), URN(""), 10, "")
+	if err == nil {
+		t.Fatal("expected account urn validation failure")
+	}
+}

--- a/internal/linkedin/ads_test.go
+++ b/internal/linkedin/ads_test.go
@@ -134,7 +134,7 @@ func TestListAccountRolesUsesAccountsFinder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("account urn: %v", err)
 	}
-	if _, err := service.ListAccountRoles(context.Background(), accountURN, 0, ""); err != nil {
+	if _, err := service.ListAccountRoles(context.Background(), accountURN, 25, "50"); err != nil {
 		t.Fatalf("list account roles: %v", err)
 	}
 
@@ -148,11 +148,82 @@ func TestListAccountRolesUsesAccountsFinder(t *testing.T) {
 	if got := req.URL.Query().Get("accounts"); got != accountURN.String() {
 		t.Fatalf("unexpected accounts query %q", got)
 	}
+	if got := req.URL.Query().Get("count"); got != "25" {
+		t.Fatalf("unexpected count query %q", got)
+	}
+	if got := req.URL.Query().Get("start"); got != "50" {
+		t.Fatalf("unexpected start query %q", got)
+	}
 	if got := req.URL.RawQuery; !strings.Contains(got, "accounts=urn:li:sponsoredAccount:123") {
 		t.Fatalf("unexpected raw query %q", got)
 	}
 	if got := req.URL.Query().Get("account"); got != "" {
 		t.Fatalf("unexpected legacy account query %q", got)
+	}
+}
+
+func TestListAccountRolesFallsBackToAuthenticatedUserOnValidationError(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusBadRequest, `{"message":"Invalid query parameters passed to request","inputErrors":[{"description":"QUERY_PARAM_NOT_ALLOWED on field accounts"}]}`),
+			responseJSON(http.StatusOK, `{"elements":[{"account":"urn:li:sponsoredAccount:123","role":"VIEWER"},{"account":"urn:li:sponsoredAccount:456","role":"ACCOUNT_MANAGER"}],"paging":{"count":2,"start":0,"total":2}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := NewAdsService(client)
+
+	accountURN, err := SponsoredAccountURN("123")
+	if err != nil {
+		t.Fatalf("account urn: %v", err)
+	}
+	result, err := service.ListAccountRoles(context.Background(), accountURN, 25, "0")
+	if err != nil {
+		t.Fatalf("list account roles: %v", err)
+	}
+	if len(result.Elements) != 1 {
+		t.Fatalf("unexpected filtered elements %#v", result.Elements)
+	}
+	if got := result.Elements[0]["account"]; got != accountURN.String() {
+		t.Fatalf("unexpected filtered account %v", got)
+	}
+	if len(httpClient.requests) != 2 {
+		t.Fatalf("expected two requests, got %d", len(httpClient.requests))
+	}
+	if got := httpClient.requests[0].URL.Query().Get("q"); got != "accounts" {
+		t.Fatalf("unexpected primary finder %q", got)
+	}
+	if got := httpClient.requests[1].URL.Query().Get("q"); got != "authenticatedUser" {
+		t.Fatalf("unexpected fallback finder %q", got)
+	}
+	if got := httpClient.requests[1].URL.Query().Get("count"); got != "25" {
+		t.Fatalf("unexpected fallback count %q", got)
+	}
+	if got := httpClient.requests[1].URL.Query().Get("start"); got != "0" {
+		t.Fatalf("unexpected fallback start %q", got)
+	}
+}
+
+func TestListAccountRolesDoesNotFallbackOnPermissionError(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusForbidden, `{"message":"Access denied"}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := NewAdsService(client)
+
+	accountURN, err := SponsoredAccountURN("123")
+	if err != nil {
+		t.Fatalf("account urn: %v", err)
+	}
+	_, err = service.ListAccountRoles(context.Background(), accountURN, 0, "")
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	if len(httpClient.requests) != 1 {
+		t.Fatalf("expected single request, got %d", len(httpClient.requests))
 	}
 }
 

--- a/internal/linkedin/ads_test.go
+++ b/internal/linkedin/ads_test.go
@@ -30,24 +30,129 @@ func TestListCampaignsBuildsExpectedRequest(t *testing.T) {
 	}
 
 	req := httpClient.requests[0]
-	if got := req.URL.Path; got != "/rest/adCampaigns" {
+	if got := req.URL.Path; got != "/rest/adAccounts/123/adCampaigns" {
 		t.Fatalf("unexpected path %q", got)
 	}
 	query := req.URL.Query()
 	if got := query.Get("q"); got != "search" {
 		t.Fatalf("unexpected q %q", got)
 	}
-	if got := query.Get("account"); got != accountURN.String() {
-		t.Fatalf("unexpected account %q", got)
+	if got := query.Get("account"); got != "" {
+		t.Fatalf("unexpected legacy account query %q", got)
 	}
-	if got := query.Get("search"); got != "spring" {
+	if got := query.Get("search"); got != "(name:(values:List(spring)))" {
 		t.Fatalf("unexpected search %q", got)
+	}
+	if got := req.URL.RawQuery; !strings.Contains(got, "search=(name:(values:List(spring)))") {
+		t.Fatalf("unexpected raw query %q", got)
 	}
 	if got := query.Get("pageSize"); got != "25" {
 		t.Fatalf("unexpected pageSize %q", got)
 	}
 	if got := query.Get("pageToken"); got != "abc" {
 		t.Fatalf("unexpected pageToken %q", got)
+	}
+}
+
+func TestListCampaignGroupsBuildsAccountScopedSearchRequest(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"id":"1"}],"paging":{"count":1}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := NewAdsService(client)
+
+	accountURN, err := SponsoredAccountURN("123")
+	if err != nil {
+		t.Fatalf("account urn: %v", err)
+	}
+	if _, err := service.ListCampaignGroups(context.Background(), accountURN, "", 100, ""); err != nil {
+		t.Fatalf("list campaign groups: %v", err)
+	}
+
+	req := httpClient.requests[0]
+	if got := req.URL.Path; got != "/rest/adAccounts/123/adCampaignGroups" {
+		t.Fatalf("unexpected path %q", got)
+	}
+	if got := req.URL.Query().Get("search"); got != "(status:(values:List(ACTIVE,ARCHIVED,CANCELED,DRAFT,PAUSED,PENDING_DELETION,REMOVED)))" {
+		t.Fatalf("unexpected default search %q", got)
+	}
+	if got := req.URL.RawQuery; !strings.Contains(got, "search=(status:(values:List(ACTIVE,ARCHIVED,CANCELED,DRAFT,PAUSED,PENDING_DELETION,REMOVED)))") {
+		t.Fatalf("unexpected raw query %q", got)
+	}
+}
+
+func TestListCreativesUsesAccountFinderRequest(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"id":"1"}],"paging":{"count":1}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := NewAdsService(client)
+
+	accountURN, err := SponsoredAccountURN("123")
+	if err != nil {
+		t.Fatalf("account urn: %v", err)
+	}
+	if _, err := service.ListCreatives(context.Background(), accountURN, "", 25, "cursor-1"); err != nil {
+		t.Fatalf("list creatives: %v", err)
+	}
+
+	req := httpClient.requests[0]
+	if got := req.URL.Path; got != "/rest/adAccounts/123/creatives" {
+		t.Fatalf("unexpected path %q", got)
+	}
+	if got := req.URL.Query().Get("q"); got != "criteria" {
+		t.Fatalf("unexpected q %q", got)
+	}
+	if got := req.Header.Get("X-RestLi-Method"); got != "FINDER" {
+		t.Fatalf("unexpected finder header %q", got)
+	}
+	if got := req.URL.Query().Get("pageToken"); got != "cursor-1" {
+		t.Fatalf("unexpected page token %q", got)
+	}
+	if got := req.URL.Query().Get("account"); got != "" {
+		t.Fatalf("unexpected legacy account query %q", got)
+	}
+}
+
+func TestListAccountRolesUsesAccountsFinder(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"role":"VIEWER"}],"paging":{"count":1}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := NewAdsService(client)
+
+	accountURN, err := SponsoredAccountURN("123")
+	if err != nil {
+		t.Fatalf("account urn: %v", err)
+	}
+	if _, err := service.ListAccountRoles(context.Background(), accountURN, 0, ""); err != nil {
+		t.Fatalf("list account roles: %v", err)
+	}
+
+	req := httpClient.requests[0]
+	if got := req.URL.Path; got != "/rest/adAccountUsers" {
+		t.Fatalf("unexpected path %q", got)
+	}
+	if got := req.URL.Query().Get("q"); got != "accounts" {
+		t.Fatalf("unexpected q %q", got)
+	}
+	if got := req.URL.Query().Get("accounts"); got != accountURN.String() {
+		t.Fatalf("unexpected accounts query %q", got)
+	}
+	if got := req.URL.RawQuery; !strings.Contains(got, "accounts=urn:li:sponsoredAccount:123") {
+		t.Fatalf("unexpected raw query %q", got)
+	}
+	if got := req.URL.Query().Get("account"); got != "" {
+		t.Fatalf("unexpected legacy account query %q", got)
 	}
 }
 

--- a/internal/linkedin/auth.go
+++ b/internal/linkedin/auth.go
@@ -72,6 +72,7 @@ type SetupInput struct {
 	RedirectURI string
 	Scopes      []string
 	AuthFlow    string
+	OnAuthURL   func(string)
 	OpenBrowser bool
 	Timeout     time.Duration
 }
@@ -214,6 +215,9 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 	authURL, err := buildAuthorizationURL(s.AuthBaseURL, profile.ClientID, listener.RedirectURI(), scopes, codeChallenge, state, authFlow)
 	if err != nil {
 		return nil, err
+	}
+	if input.OnAuthURL != nil {
+		input.OnAuthURL(authURL)
 	}
 
 	if input.OpenBrowser {

--- a/internal/linkedin/auth.go
+++ b/internal/linkedin/auth.go
@@ -19,12 +19,20 @@ const (
 	ProviderLinkedIn              = "linkedin"
 	DefaultAuthBaseURL            = "https://www.linkedin.com"
 	DefaultAPIBaseURL             = "https://api.linkedin.com"
-	authorizationEndpointPath     = "/oauth/native-pkce/authorization"
+	standardAuthorizationPath     = "/oauth/v2/authorization"
+	nativePKCEAuthorizationPath   = "/oauth/native-pkce/authorization"
 	tokenEndpointPath             = "/oauth/v2/accessToken"
 	meEndpointPath                = "/v2/me"
 	restLiProtocolVersion         = "2.0.0"
 	defaultRefreshExpirySkew      = 0
 	defaultRequestTimeoutFallback = 30 * time.Second
+)
+
+type AuthFlow string
+
+const (
+	AuthFlowStandard   AuthFlow = "standard"
+	AuthFlowNativePKCE AuthFlow = "native-pkce"
 )
 
 type HTTPClient interface {
@@ -63,6 +71,7 @@ type SetupInput struct {
 	Profile     string
 	RedirectURI string
 	Scopes      []string
+	AuthFlow    string
 	OpenBrowser bool
 	Timeout     time.Duration
 }
@@ -70,6 +79,7 @@ type SetupInput struct {
 type SetupResult struct {
 	ProfileName string        `json:"profile_name"`
 	State       string        `json:"state"`
+	AuthFlow    string        `json:"auth_flow"`
 	AuthURL     string        `json:"auth_url"`
 	RedirectURI string        `json:"redirect_uri"`
 	Token       TokenBundle   `json:"token"`
@@ -161,16 +171,28 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		input.Timeout = 180 * time.Second
 	}
 
-	clientSecret, err := s.loadSecret(profile.ClientSecretRef)
-	if err != nil {
-		return nil, fmt.Errorf("load client secret for profile %q: %w", profileName, err)
-	}
-	_ = clientSecret
-
-	codeVerifier, codeChallenge, err := newPKCE()
+	authFlow, err := normalizeAuthFlow(input.AuthFlow)
 	if err != nil {
 		return nil, err
 	}
+
+	clientSecret := ""
+	if authFlow == AuthFlowStandard {
+		clientSecret, err = s.loadSecret(profile.ClientSecretRef)
+		if err != nil {
+			return nil, fmt.Errorf("load client secret for profile %q: %w", profileName, err)
+		}
+	}
+
+	codeVerifier := ""
+	codeChallenge := ""
+	if authFlow == AuthFlowNativePKCE {
+		codeVerifier, codeChallenge, err = newPKCE()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	state, err := newState()
 	if err != nil {
 		return nil, err
@@ -189,7 +211,7 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		scopes = normalizeScopes(profile.Scopes)
 	}
 
-	authURL, err := buildAuthorizationURL(s.AuthBaseURL, profile.ClientID, listener.RedirectURI(), scopes, codeChallenge, state)
+	authURL, err := buildAuthorizationURL(s.AuthBaseURL, profile.ClientID, listener.RedirectURI(), scopes, codeChallenge, state, authFlow)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +227,7 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		return nil, err
 	}
 
-	token, err := s.exchangeAuthorizationCode(ctx, profile, code, codeVerifier, listener.RedirectURI())
+	token, err := s.exchangeAuthorizationCode(ctx, profile, code, codeVerifier, listener.RedirectURI(), clientSecret, authFlow)
 	if err != nil {
 		return nil, err
 	}
@@ -222,6 +244,7 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 	return &SetupResult{
 		ProfileName: profileName,
 		State:       state,
+		AuthFlow:    string(authFlow),
 		AuthURL:     authURL,
 		RedirectURI: listener.RedirectURI(),
 		Token:       token,
@@ -281,13 +304,26 @@ func (s *Service) WhoAmIWithToken(ctx context.Context, version string, accessTok
 	return parseWhoAmI(payload), nil
 }
 
-func (s *Service) exchangeAuthorizationCode(ctx context.Context, profile Profile, code string, codeVerifier string, redirectURI string) (TokenBundle, error) {
+func (s *Service) exchangeAuthorizationCode(ctx context.Context, profile Profile, code string, codeVerifier string, redirectURI string, clientSecret string, authFlow AuthFlow) (TokenBundle, error) {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
 	form.Set("redirect_uri", redirectURI)
 	form.Set("client_id", profile.ClientID)
-	form.Set("code_verifier", codeVerifier)
+	switch authFlow {
+	case AuthFlowStandard:
+		if strings.TrimSpace(clientSecret) == "" {
+			return TokenBundle{}, errors.New("client secret is required for LinkedIn standard auth flow")
+		}
+		form.Set("client_secret", clientSecret)
+	case AuthFlowNativePKCE:
+		if strings.TrimSpace(codeVerifier) == "" {
+			return TokenBundle{}, errors.New("code verifier is required for LinkedIn native PKCE auth flow")
+		}
+		form.Set("code_verifier", codeVerifier)
+	default:
+		return TokenBundle{}, fmt.Errorf("unsupported LinkedIn auth flow %q", authFlow)
+	}
 
 	var payload tokenEndpointResponse
 	if err := s.doTokenRequest(ctx, form, &payload); err != nil {
@@ -511,15 +547,12 @@ func (s *Service) doRequest(req *http.Request, out any) error {
 	return nil
 }
 
-func buildAuthorizationURL(authBaseURL string, clientID string, redirectURI string, scopes []string, codeChallenge string, state string) (string, error) {
+func buildAuthorizationURL(authBaseURL string, clientID string, redirectURI string, scopes []string, codeChallenge string, state string, authFlow AuthFlow) (string, error) {
 	if strings.TrimSpace(clientID) == "" {
 		return "", errors.New("client id is required")
 	}
 	if strings.TrimSpace(redirectURI) == "" {
 		return "", errors.New("redirect uri is required")
-	}
-	if strings.TrimSpace(codeChallenge) == "" {
-		return "", errors.New("code challenge is required")
 	}
 	if strings.TrimSpace(state) == "" {
 		return "", errors.New("state is required")
@@ -529,20 +562,43 @@ func buildAuthorizationURL(authBaseURL string, clientID string, redirectURI stri
 	if err != nil {
 		return "", fmt.Errorf("parse linkedin auth base url: %w", err)
 	}
-	endpoint.Path = authorizationEndpointPath
+	switch authFlow {
+	case AuthFlowStandard:
+		endpoint.Path = standardAuthorizationPath
+	case AuthFlowNativePKCE:
+		if strings.TrimSpace(codeChallenge) == "" {
+			return "", errors.New("code challenge is required")
+		}
+		endpoint.Path = nativePKCEAuthorizationPath
+	default:
+		return "", fmt.Errorf("unsupported LinkedIn auth flow %q", authFlow)
+	}
 
 	values := url.Values{}
 	values.Set("response_type", "code")
 	values.Set("client_id", clientID)
 	values.Set("redirect_uri", redirectURI)
 	values.Set("state", state)
-	values.Set("code_challenge", codeChallenge)
-	values.Set("code_challenge_method", "S256")
+	if authFlow == AuthFlowNativePKCE {
+		values.Set("code_challenge", codeChallenge)
+		values.Set("code_challenge_method", "S256")
+	}
 	if len(scopes) > 0 {
 		values.Set("scope", strings.Join(normalizeScopes(scopes), " "))
 	}
 	endpoint.RawQuery = values.Encode()
 	return endpoint.String(), nil
+}
+
+func normalizeAuthFlow(raw string) (AuthFlow, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", string(AuthFlowStandard):
+		return AuthFlowStandard, nil
+	case string(AuthFlowNativePKCE):
+		return AuthFlowNativePKCE, nil
+	default:
+		return "", fmt.Errorf("unsupported LinkedIn auth flow %q (expected %q or %q)", raw, AuthFlowStandard, AuthFlowNativePKCE)
+	}
 }
 
 func parseTokenBundle(now time.Time, response tokenEndpointResponse) (TokenBundle, error) {

--- a/internal/linkedin/auth.go
+++ b/internal/linkedin/auth.go
@@ -85,7 +85,8 @@ type SetupResult struct {
 	AuthURL     string        `json:"auth_url"`
 	RedirectURI string        `json:"redirect_uri"`
 	Token       TokenBundle   `json:"token"`
-	WhoAmI      *WhoAmIResult `json:"whoami,omitempty"`
+	WhoAmI      *WhoAmIResult `json:"whoami"`
+	Warnings    []string      `json:"warnings,omitempty"`
 	Refreshed   bool          `json:"refreshed"`
 }
 
@@ -94,6 +95,7 @@ type ValidateResult struct {
 	Refreshed   bool          `json:"refreshed"`
 	Token       TokenBundle   `json:"token"`
 	WhoAmI      *WhoAmIResult `json:"whoami"`
+	Warnings    []string      `json:"warnings,omitempty"`
 }
 
 type TokenBundle struct {
@@ -256,7 +258,7 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		return nil, err
 	}
 
-	whoami, err := s.WhoAmIWithToken(ctx, profile.LinkedInVersion, token.AccessToken)
+	whoami, warnings, err := s.resolveWhoAmIBestEffort(ctx, profile.LinkedInVersion, token.AccessToken, token.Scopes)
 	if err != nil {
 		return nil, err
 	}
@@ -269,6 +271,7 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		RedirectURI: oauthRedirectURI,
 		Token:       token,
 		WhoAmI:      whoami,
+		Warnings:    warnings,
 		Refreshed:   false,
 	}, nil
 }
@@ -278,7 +281,7 @@ func (s *Service) Validate(ctx context.Context, profileName string) (*ValidateRe
 	if err != nil {
 		return nil, err
 	}
-	whoami, err := s.WhoAmIWithToken(ctx, profile.LinkedInVersion, token.AccessToken)
+	whoami, warnings, err := s.resolveWhoAmIBestEffort(ctx, profile.LinkedInVersion, token.AccessToken, token.Scopes)
 	if err != nil {
 		return nil, err
 	}
@@ -287,6 +290,7 @@ func (s *Service) Validate(ctx context.Context, profileName string) (*ValidateRe
 		Refreshed:   refreshed,
 		Token:       token,
 		WhoAmI:      whoami,
+		Warnings:    warnings,
 	}, nil
 }
 
@@ -706,6 +710,16 @@ func normalizeScopes(scopes []string) []string {
 	return out
 }
 
+func hasLinkedInIdentityScope(scopes []string) bool {
+	for _, scope := range normalizeScopes(scopes) {
+		switch scope {
+		case "r_liteprofile", "r_basicprofile", "openid", "profile":
+			return true
+		}
+	}
+	return false
+}
+
 func needsRefresh(now time.Time, expiresAt time.Time) bool {
 	if expiresAt.IsZero() {
 		return false
@@ -734,6 +748,34 @@ func parseWhoAmI(payload map[string]any) *WhoAmIResult {
 		}
 	}
 	return result
+}
+
+func (s *Service) resolveWhoAmIBestEffort(ctx context.Context, version string, accessToken string, scopes []string) (*WhoAmIResult, []string, error) {
+	if !hasLinkedInIdentityScope(scopes) {
+		return nil, []string{"LinkedIn member profile lookup skipped; granted scopes do not include an identity scope such as r_liteprofile."}, nil
+	}
+
+	whoami, err := s.WhoAmIWithToken(ctx, version, accessToken)
+	if err == nil {
+		return whoami, nil, nil
+	}
+	if shouldSuppressWhoAmIError(err) {
+		return nil, []string{formatWhoAmIWarning(err)}, nil
+	}
+	return nil, nil, err
+}
+
+func shouldSuppressWhoAmIError(err error) bool {
+	var apiErr *Error
+	return errors.As(err, &apiErr) && apiErr.Category == ErrorCategoryPermission
+}
+
+func formatWhoAmIWarning(err error) string {
+	var apiErr *Error
+	if errors.As(err, &apiErr) && strings.TrimSpace(apiErr.Message) != "" {
+		return fmt.Sprintf("LinkedIn member profile lookup unavailable; continuing without whoami. Reason: %s", strings.TrimSpace(apiErr.Message))
+	}
+	return "LinkedIn member profile lookup unavailable; continuing without whoami."
 }
 
 func pickLinkedInName(payload map[string]any, kind string) string {

--- a/internal/linkedin/auth.go
+++ b/internal/linkedin/auth.go
@@ -69,6 +69,7 @@ type Profile struct {
 
 type SetupInput struct {
 	Profile     string
+	ListenerURI string
 	RedirectURI string
 	Scopes      []string
 	AuthFlow    string
@@ -166,7 +167,9 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		return nil, err
 	}
 	if strings.TrimSpace(input.RedirectURI) == "" {
-		return nil, errors.New("redirect uri is required")
+		if strings.TrimSpace(input.ListenerURI) == "" {
+			return nil, errors.New("redirect uri is required")
+		}
 	}
 	if input.Timeout <= 0 {
 		input.Timeout = 180 * time.Second
@@ -174,6 +177,9 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 
 	authFlow, err := normalizeAuthFlow(input.AuthFlow)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateSetupRedirectURI(input.RedirectURI, authFlow); err != nil {
 		return nil, err
 	}
 
@@ -199,7 +205,12 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		return nil, err
 	}
 
-	listener, err := newListener(input.RedirectURI, state)
+	listenerURI := strings.TrimSpace(input.ListenerURI)
+	if listenerURI == "" {
+		listenerURI = strings.TrimSpace(input.RedirectURI)
+	}
+
+	listener, err := newListener(listenerURI, state)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +223,12 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		scopes = normalizeScopes(profile.Scopes)
 	}
 
-	authURL, err := buildAuthorizationURL(s.AuthBaseURL, profile.ClientID, listener.RedirectURI(), scopes, codeChallenge, state, authFlow)
+	oauthRedirectURI := strings.TrimSpace(input.RedirectURI)
+	if oauthRedirectURI == "" {
+		oauthRedirectURI = listener.RedirectURI()
+	}
+
+	authURL, err := buildAuthorizationURL(s.AuthBaseURL, profile.ClientID, oauthRedirectURI, scopes, codeChallenge, state, authFlow)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +247,7 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		return nil, err
 	}
 
-	token, err := s.exchangeAuthorizationCode(ctx, profile, code, codeVerifier, listener.RedirectURI(), clientSecret, authFlow)
+	token, err := s.exchangeAuthorizationCode(ctx, profile, code, codeVerifier, oauthRedirectURI, clientSecret, authFlow)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +266,7 @@ func (s *Service) Setup(ctx context.Context, profileName string, input SetupInpu
 		State:       state,
 		AuthFlow:    string(authFlow),
 		AuthURL:     authURL,
-		RedirectURI: listener.RedirectURI(),
+		RedirectURI: oauthRedirectURI,
 		Token:       token,
 		WhoAmI:      whoami,
 		Refreshed:   false,
@@ -602,6 +618,40 @@ func normalizeAuthFlow(raw string) (AuthFlow, error) {
 		return AuthFlowNativePKCE, nil
 	default:
 		return "", fmt.Errorf("unsupported LinkedIn auth flow %q (expected %q or %q)", raw, AuthFlowStandard, AuthFlowNativePKCE)
+	}
+}
+
+func validateSetupRedirectURI(raw string, authFlow AuthFlow) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid redirect uri %q: %w", raw, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid redirect uri %q: expected absolute URI", raw)
+	}
+
+	switch parsed.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+		if host == "127.0.0.1" || host == "localhost" {
+			return nil
+		}
+		if authFlow == AuthFlowStandard {
+			return fmt.Errorf("invalid redirect uri %q: standard flow requires https or loopback http (localhost/127.0.0.1)", raw)
+		}
+		return fmt.Errorf("invalid redirect uri %q: native-pkce flow requires https or loopback http (localhost/127.0.0.1)", raw)
+	default:
+		if authFlow == AuthFlowStandard {
+			return fmt.Errorf("invalid redirect uri %q: standard flow requires https or loopback http (localhost/127.0.0.1)", raw)
+		}
+		return fmt.Errorf("invalid redirect uri %q: native-pkce flow requires https or loopback http (localhost/127.0.0.1)", raw)
 	}
 }
 

--- a/internal/linkedin/auth.go
+++ b/internal/linkedin/auth.go
@@ -1,0 +1,740 @@
+package linkedin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	sharedauth "github.com/bilalbayram/metacli/internal/auth"
+)
+
+const (
+	ProviderLinkedIn              = "linkedin"
+	DefaultAuthBaseURL            = "https://www.linkedin.com"
+	DefaultAPIBaseURL             = "https://api.linkedin.com"
+	authorizationEndpointPath     = "/oauth/native-pkce/authorization"
+	tokenEndpointPath             = "/oauth/v2/accessToken"
+	meEndpointPath                = "/v2/me"
+	restLiProtocolVersion         = "2.0.0"
+	defaultRefreshExpirySkew      = 0
+	defaultRequestTimeoutFallback = 30 * time.Second
+)
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type SecretStore interface {
+	Set(ref string, value string) error
+	Get(ref string) (string, error)
+}
+
+type ProfileStore interface {
+	Get(name string) (Profile, error)
+	Upsert(name string, profile Profile) error
+}
+
+type oauthCodeListener interface {
+	RedirectURI() string
+	Wait(context.Context, time.Duration) (string, error)
+	Close(context.Context) error
+}
+
+type Profile struct {
+	Provider              string
+	LinkedInVersion       string
+	ClientID              string
+	ClientSecretRef       string
+	AccessTokenRef        string
+	RefreshTokenRef       string
+	Scopes                []string
+	AccessTokenExpiresAt  time.Time
+	RefreshTokenExpiresAt time.Time
+}
+
+type SetupInput struct {
+	Profile     string
+	RedirectURI string
+	Scopes      []string
+	OpenBrowser bool
+	Timeout     time.Duration
+}
+
+type SetupResult struct {
+	ProfileName string        `json:"profile_name"`
+	State       string        `json:"state"`
+	AuthURL     string        `json:"auth_url"`
+	RedirectURI string        `json:"redirect_uri"`
+	Token       TokenBundle   `json:"token"`
+	WhoAmI      *WhoAmIResult `json:"whoami,omitempty"`
+	Refreshed   bool          `json:"refreshed"`
+}
+
+type ValidateResult struct {
+	ProfileName string        `json:"profile_name"`
+	Refreshed   bool          `json:"refreshed"`
+	Token       TokenBundle   `json:"token"`
+	WhoAmI      *WhoAmIResult `json:"whoami"`
+}
+
+type TokenBundle struct {
+	AccessToken           string    `json:"access_token"`
+	RefreshToken          string    `json:"refresh_token,omitempty"`
+	AccessTokenExpiresAt  time.Time `json:"access_token_expires_at"`
+	RefreshTokenExpiresAt time.Time `json:"refresh_token_expires_at,omitempty"`
+	Scopes                []string  `json:"scopes"`
+}
+
+type WhoAmIResult struct {
+	ID        string         `json:"id,omitempty"`
+	FirstName string         `json:"first_name,omitempty"`
+	LastName  string         `json:"last_name,omitempty"`
+	FullName  string         `json:"full_name,omitempty"`
+	Raw       map[string]any `json:"raw,omitempty"`
+}
+
+type tokenEndpointResponse struct {
+	AccessToken           string `json:"access_token"`
+	ExpiresIn             int64  `json:"expires_in"`
+	RefreshToken          string `json:"refresh_token"`
+	RefreshTokenExpiresIn int64  `json:"refresh_token_expires_in"`
+	Scope                 string `json:"scope"`
+}
+
+type Service struct {
+	HTTPClient  HTTPClient
+	AuthBaseURL string
+	APIBaseURL  string
+	Now         func() time.Time
+	Profiles    ProfileStore
+	Secrets     SecretStore
+}
+
+var (
+	newPKCE     = sharedauth.NewPKCE
+	newState    = sharedauth.NewOAuthState
+	newListener = func(redirectURI string, state string) (oauthCodeListener, error) {
+		return sharedauth.NewOAuthCallbackListener(redirectURI, state)
+	}
+	openBrowser = sharedauth.OpenBrowser
+)
+
+func NewService(httpClient HTTPClient, authBaseURL string, apiBaseURL string, profiles ProfileStore, secrets SecretStore) *Service {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultRequestTimeoutFallback}
+	}
+	if strings.TrimSpace(authBaseURL) == "" {
+		authBaseURL = DefaultAuthBaseURL
+	}
+	if strings.TrimSpace(apiBaseURL) == "" {
+		apiBaseURL = DefaultAPIBaseURL
+	}
+	return &Service{
+		HTTPClient:  httpClient,
+		AuthBaseURL: strings.TrimSuffix(strings.TrimSpace(authBaseURL), "/"),
+		APIBaseURL:  strings.TrimSuffix(strings.TrimSpace(apiBaseURL), "/"),
+		Now:         time.Now,
+		Profiles:    profiles,
+		Secrets:     secrets,
+	}
+}
+
+func (s *Service) Setup(ctx context.Context, profileName string, input SetupInput) (*SetupResult, error) {
+	profile, err := s.loadProfile(profileName)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateLinkedInProfile(profile); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(input.RedirectURI) == "" {
+		return nil, errors.New("redirect uri is required")
+	}
+	if input.Timeout <= 0 {
+		input.Timeout = 180 * time.Second
+	}
+
+	clientSecret, err := s.loadSecret(profile.ClientSecretRef)
+	if err != nil {
+		return nil, fmt.Errorf("load client secret for profile %q: %w", profileName, err)
+	}
+	_ = clientSecret
+
+	codeVerifier, codeChallenge, err := newPKCE()
+	if err != nil {
+		return nil, err
+	}
+	state, err := newState()
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := newListener(input.RedirectURI, state)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = listener.Close(context.Background())
+	}()
+
+	scopes := normalizeScopes(input.Scopes)
+	if len(scopes) == 0 {
+		scopes = normalizeScopes(profile.Scopes)
+	}
+
+	authURL, err := buildAuthorizationURL(s.AuthBaseURL, profile.ClientID, listener.RedirectURI(), scopes, codeChallenge, state)
+	if err != nil {
+		return nil, err
+	}
+
+	if input.OpenBrowser {
+		if err := openBrowser(authURL); err != nil {
+			return nil, err
+		}
+	}
+
+	code, err := listener.Wait(ctx, input.Timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := s.exchangeAuthorizationCode(ctx, profile, code, codeVerifier, listener.RedirectURI())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.persistTokenBundle(profileName, profile, token); err != nil {
+		return nil, err
+	}
+
+	whoami, err := s.WhoAmIWithToken(ctx, profile.LinkedInVersion, token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SetupResult{
+		ProfileName: profileName,
+		State:       state,
+		AuthURL:     authURL,
+		RedirectURI: listener.RedirectURI(),
+		Token:       token,
+		WhoAmI:      whoami,
+		Refreshed:   false,
+	}, nil
+}
+
+func (s *Service) Validate(ctx context.Context, profileName string) (*ValidateResult, error) {
+	profile, token, refreshed, err := s.resolveActiveToken(ctx, profileName)
+	if err != nil {
+		return nil, err
+	}
+	whoami, err := s.WhoAmIWithToken(ctx, profile.LinkedInVersion, token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidateResult{
+		ProfileName: profileName,
+		Refreshed:   refreshed,
+		Token:       token,
+		WhoAmI:      whoami,
+	}, nil
+}
+
+func (s *Service) Scopes(ctx context.Context, profileName string) ([]string, error) {
+	profile, token, _, err := s.resolveActiveToken(ctx, profileName)
+	if err != nil {
+		return nil, err
+	}
+	if len(token.Scopes) > 0 {
+		return append([]string(nil), token.Scopes...), nil
+	}
+	return append([]string(nil), profile.Scopes...), nil
+}
+
+func (s *Service) WhoAmI(ctx context.Context, profileName string) (*WhoAmIResult, error) {
+	profile, token, _, err := s.resolveActiveToken(ctx, profileName)
+	if err != nil {
+		return nil, err
+	}
+	return s.WhoAmIWithToken(ctx, profile.LinkedInVersion, token.AccessToken)
+}
+
+func (s *Service) WhoAmIWithToken(ctx context.Context, version string, accessToken string) (*WhoAmIResult, error) {
+	if strings.TrimSpace(accessToken) == "" {
+		return nil, errors.New("access token is required")
+	}
+	if strings.TrimSpace(version) == "" {
+		return nil, errors.New("linkedin version is required")
+	}
+
+	var payload map[string]any
+	if err := s.doJSONRequest(ctx, http.MethodGet, meEndpointPath, version, nil, accessToken, nil, &payload); err != nil {
+		return nil, err
+	}
+	return parseWhoAmI(payload), nil
+}
+
+func (s *Service) exchangeAuthorizationCode(ctx context.Context, profile Profile, code string, codeVerifier string, redirectURI string) (TokenBundle, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", profile.ClientID)
+	form.Set("code_verifier", codeVerifier)
+
+	var payload tokenEndpointResponse
+	if err := s.doTokenRequest(ctx, form, &payload); err != nil {
+		return TokenBundle{}, err
+	}
+	return parseTokenBundle(s.Now(), payload)
+}
+
+func (s *Service) RefreshAccessToken(ctx context.Context, profileName string) (TokenBundle, error) {
+	profile, err := s.loadProfile(profileName)
+	if err != nil {
+		return TokenBundle{}, err
+	}
+	if err := validateLinkedInProfile(profile); err != nil {
+		return TokenBundle{}, err
+	}
+	refreshToken, err := s.loadSecret(profile.RefreshTokenRef)
+	if err != nil {
+		return TokenBundle{}, fmt.Errorf("load refresh token for profile %q: %w", profileName, err)
+	}
+	clientSecret, err := s.loadSecret(profile.ClientSecretRef)
+	if err != nil {
+		return TokenBundle{}, fmt.Errorf("load client secret for profile %q: %w", profileName, err)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", profile.ClientID)
+	form.Set("client_secret", clientSecret)
+
+	var payload tokenEndpointResponse
+	if err := s.doTokenRequest(ctx, form, &payload); err != nil {
+		return TokenBundle{}, err
+	}
+	bundle, err := parseTokenBundle(s.Now(), payload)
+	if err != nil {
+		return TokenBundle{}, err
+	}
+	if bundle.RefreshToken == "" {
+		bundle.RefreshToken = refreshToken
+	}
+	if err := s.persistTokenBundle(profileName, profile, bundle); err != nil {
+		return TokenBundle{}, err
+	}
+	return bundle, nil
+}
+
+func (s *Service) resolveActiveToken(ctx context.Context, profileName string) (Profile, TokenBundle, bool, error) {
+	profile, err := s.loadProfile(profileName)
+	if err != nil {
+		return Profile{}, TokenBundle{}, false, err
+	}
+	if err := validateLinkedInProfile(profile); err != nil {
+		return Profile{}, TokenBundle{}, false, err
+	}
+
+	accessToken, err := s.loadSecret(profile.AccessTokenRef)
+	if err != nil {
+		return Profile{}, TokenBundle{}, false, fmt.Errorf("load access token for profile %q: %w", profileName, err)
+	}
+	refreshToken := ""
+	if strings.TrimSpace(profile.RefreshTokenRef) != "" {
+		refreshToken, _ = s.loadSecret(profile.RefreshTokenRef)
+	}
+
+	bundle := TokenBundle{
+		AccessToken:           accessToken,
+		RefreshToken:          refreshToken,
+		AccessTokenExpiresAt:  profile.AccessTokenExpiresAt,
+		RefreshTokenExpiresAt: profile.RefreshTokenExpiresAt,
+		Scopes:                append([]string(nil), profile.Scopes...),
+	}
+	if !needsRefresh(s.Now(), profile.AccessTokenExpiresAt) {
+		return profile, bundle, false, nil
+	}
+	if strings.TrimSpace(profile.RefreshTokenRef) == "" || strings.TrimSpace(refreshToken) == "" {
+		return profile, bundle, false, fmt.Errorf("profile %q access token expired and refresh token is unavailable", profileName)
+	}
+
+	refreshed, err := s.refreshFromSecret(ctx, profileName, profile, refreshToken)
+	if err != nil {
+		return profile, bundle, false, err
+	}
+	return profile, refreshed, true, nil
+}
+
+func (s *Service) refreshFromSecret(ctx context.Context, profileName string, profile Profile, refreshToken string) (TokenBundle, error) {
+	clientSecret, err := s.loadSecret(profile.ClientSecretRef)
+	if err != nil {
+		return TokenBundle{}, fmt.Errorf("load client secret for profile %q: %w", profileName, err)
+	}
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", profile.ClientID)
+	form.Set("client_secret", clientSecret)
+
+	var payload tokenEndpointResponse
+	if err := s.doTokenRequest(ctx, form, &payload); err != nil {
+		return TokenBundle{}, err
+	}
+	bundle, err := parseTokenBundle(s.Now(), payload)
+	if err != nil {
+		return TokenBundle{}, err
+	}
+	if bundle.RefreshToken == "" {
+		bundle.RefreshToken = refreshToken
+	}
+	if err := s.persistTokenBundle(profileName, profile, bundle); err != nil {
+		return TokenBundle{}, err
+	}
+	return bundle, nil
+}
+
+func (s *Service) persistTokenBundle(profileName string, profile Profile, bundle TokenBundle) error {
+	if strings.TrimSpace(profile.AccessTokenRef) == "" {
+		return fmt.Errorf("profile %q access_token_ref is required", profileName)
+	}
+	if err := s.Secrets.Set(profile.AccessTokenRef, bundle.AccessToken); err != nil {
+		return err
+	}
+	if strings.TrimSpace(profile.RefreshTokenRef) != "" && strings.TrimSpace(bundle.RefreshToken) != "" {
+		if err := s.Secrets.Set(profile.RefreshTokenRef, bundle.RefreshToken); err != nil {
+			return err
+		}
+	}
+	profile.AccessTokenExpiresAt = bundle.AccessTokenExpiresAt
+	profile.RefreshTokenExpiresAt = bundle.RefreshTokenExpiresAt
+	profile.Scopes = append([]string(nil), bundle.Scopes...)
+	return s.saveProfile(profileName, profile)
+}
+
+func (s *Service) doTokenRequest(ctx context.Context, form url.Values, out any) error {
+	endpoint, err := url.Parse(s.AuthBaseURL)
+	if err != nil {
+		return fmt.Errorf("parse linkedin auth base url: %w", err)
+	}
+	endpoint.Path = joinLinkedInPath(endpoint.Path, tokenEndpointPath)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("build linkedin token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	return s.doRequest(req, out)
+}
+
+func (s *Service) doJSONRequest(ctx context.Context, method string, path string, version string, query map[string]string, accessToken string, body any, out any) error {
+	endpoint, err := url.Parse(s.APIBaseURL)
+	if err != nil {
+		return fmt.Errorf("parse linkedin api base url: %w", err)
+	}
+	endpoint.Path = strings.TrimSuffix(endpoint.Path, "/") + path
+	values := url.Values{}
+	for key, value := range query {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		values.Set(key, value)
+	}
+	endpoint.RawQuery = values.Encode()
+
+	var bodyReader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal linkedin api request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(raw)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bodyReader)
+	if err != nil {
+		return fmt.Errorf("build linkedin api request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-Restli-Protocol-Version", restLiProtocolVersion)
+	if strings.TrimSpace(version) != "" {
+		req.Header.Set("LinkedIn-Version", version)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return s.doRequest(req, out)
+}
+
+func (s *Service) doRequest(req *http.Request, out any) error {
+	client := s.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultRequestTimeoutFallback}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request %s: %w", req.URL.String(), err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response %s: %w", req.URL.String(), err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return classifyLinkedInError(resp.StatusCode, body)
+	}
+	if out == nil {
+		return nil
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode response %s: %w", req.URL.String(), err)
+	}
+	return nil
+}
+
+func buildAuthorizationURL(authBaseURL string, clientID string, redirectURI string, scopes []string, codeChallenge string, state string) (string, error) {
+	if strings.TrimSpace(clientID) == "" {
+		return "", errors.New("client id is required")
+	}
+	if strings.TrimSpace(redirectURI) == "" {
+		return "", errors.New("redirect uri is required")
+	}
+	if strings.TrimSpace(codeChallenge) == "" {
+		return "", errors.New("code challenge is required")
+	}
+	if strings.TrimSpace(state) == "" {
+		return "", errors.New("state is required")
+	}
+
+	endpoint, err := url.Parse(strings.TrimRight(strings.TrimSpace(authBaseURL), "/"))
+	if err != nil {
+		return "", fmt.Errorf("parse linkedin auth base url: %w", err)
+	}
+	endpoint.Path = authorizationEndpointPath
+
+	values := url.Values{}
+	values.Set("response_type", "code")
+	values.Set("client_id", clientID)
+	values.Set("redirect_uri", redirectURI)
+	values.Set("state", state)
+	values.Set("code_challenge", codeChallenge)
+	values.Set("code_challenge_method", "S256")
+	if len(scopes) > 0 {
+		values.Set("scope", strings.Join(normalizeScopes(scopes), " "))
+	}
+	endpoint.RawQuery = values.Encode()
+	return endpoint.String(), nil
+}
+
+func parseTokenBundle(now time.Time, response tokenEndpointResponse) (TokenBundle, error) {
+	if strings.TrimSpace(response.AccessToken) == "" {
+		return TokenBundle{}, errors.New("linkedin token response did not include access_token")
+	}
+	bundle := TokenBundle{
+		AccessToken:  response.AccessToken,
+		RefreshToken: strings.TrimSpace(response.RefreshToken),
+		Scopes:       parseScopeList(response.Scope),
+	}
+	if response.ExpiresIn > 0 {
+		bundle.AccessTokenExpiresAt = now.UTC().Add(time.Duration(response.ExpiresIn) * time.Second)
+	}
+	if response.RefreshTokenExpiresIn > 0 {
+		bundle.RefreshTokenExpiresAt = now.UTC().Add(time.Duration(response.RefreshTokenExpiresIn) * time.Second)
+	}
+	return bundle, nil
+}
+
+func parseScopeList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		switch r {
+		case ' ', ',', '\t', '\n', '\r':
+			return true
+		default:
+			return false
+		}
+	})
+	return normalizeScopes(fields)
+}
+
+func normalizeScopes(scopes []string) []string {
+	out := make([]string, 0, len(scopes))
+	seen := map[string]struct{}{}
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		if _, exists := seen[scope]; exists {
+			continue
+		}
+		seen[scope] = struct{}{}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func needsRefresh(now time.Time, expiresAt time.Time) bool {
+	if expiresAt.IsZero() {
+		return false
+	}
+	return !now.UTC().Before(expiresAt.UTC())
+}
+
+func parseWhoAmI(payload map[string]any) *WhoAmIResult {
+	if len(payload) == 0 {
+		return &WhoAmIResult{Raw: map[string]any{}}
+	}
+	result := &WhoAmIResult{
+		Raw: cloneMap(payload),
+	}
+	if id, _ := payload["id"].(string); strings.TrimSpace(id) != "" {
+		result.ID = strings.TrimSpace(id)
+	}
+	result.FirstName = pickLinkedInName(payload, "first")
+	result.LastName = pickLinkedInName(payload, "last")
+	if first, last := strings.TrimSpace(result.FirstName), strings.TrimSpace(result.LastName); first != "" || last != "" {
+		result.FullName = strings.TrimSpace(strings.Join([]string{first, last}, " "))
+	}
+	if result.FullName == "" {
+		if full, _ := payload["localizedFullName"].(string); strings.TrimSpace(full) != "" {
+			result.FullName = strings.TrimSpace(full)
+		}
+	}
+	return result
+}
+
+func pickLinkedInName(payload map[string]any, kind string) string {
+	if payload == nil {
+		return ""
+	}
+	flatKey := "localizedFirstName"
+	if kind == "last" {
+		flatKey = "localizedLastName"
+	}
+	if flat, _ := payload[flatKey].(string); strings.TrimSpace(flat) != "" {
+		return strings.TrimSpace(flat)
+	}
+	raw, _ := payload[kind+"Name"].(map[string]any)
+	if len(raw) == 0 {
+		return ""
+	}
+	if localized, _ := raw["localized"].(map[string]any); len(localized) > 0 {
+		if preferred := preferredLocaleKey(raw); preferred != "" {
+			if value, ok := localized[preferred].(string); ok && strings.TrimSpace(value) != "" {
+				return strings.TrimSpace(value)
+			}
+		}
+		for _, value := range localized {
+			if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return ""
+}
+
+func preferredLocaleKey(raw map[string]any) string {
+	preferred, _ := raw["preferredLocale"].(map[string]any)
+	if len(preferred) == 0 {
+		return ""
+	}
+	lang, _ := preferred["language"].(string)
+	country, _ := preferred["country"].(string)
+	lang = strings.TrimSpace(lang)
+	country = strings.TrimSpace(country)
+	if lang == "" || country == "" {
+		return ""
+	}
+	return strings.ToLower(lang) + "_" + strings.ToUpper(country)
+}
+
+func cloneMap(source map[string]any) map[string]any {
+	if len(source) == 0 {
+		return map[string]any{}
+	}
+	clone := make(map[string]any, len(source))
+	for key, value := range source {
+		clone[key] = cloneAny(value)
+	}
+	return clone
+}
+
+func validateLinkedInProfile(profile Profile) error {
+	if strings.TrimSpace(profile.Provider) != "" && strings.TrimSpace(profile.Provider) != ProviderLinkedIn {
+		return fmt.Errorf("unsupported provider %q", profile.Provider)
+	}
+	if strings.TrimSpace(profile.ClientID) == "" {
+		return errors.New("client id is required")
+	}
+	if strings.TrimSpace(profile.ClientSecretRef) == "" {
+		return errors.New("client secret ref is required")
+	}
+	if strings.TrimSpace(profile.AccessTokenRef) == "" {
+		return errors.New("access token ref is required")
+	}
+	if strings.TrimSpace(profile.RefreshTokenRef) == "" {
+		return errors.New("refresh token ref is required")
+	}
+	if strings.TrimSpace(profile.LinkedInVersion) == "" {
+		return errors.New("linkedin version is required")
+	}
+	return nil
+}
+
+func (s *Service) loadProfile(profileName string) (Profile, error) {
+	if s.Profiles == nil {
+		return Profile{}, errors.New("profile store is required")
+	}
+	profileName = strings.TrimSpace(profileName)
+	if profileName == "" {
+		return Profile{}, errors.New("profile name is required")
+	}
+	profile, err := s.Profiles.Get(profileName)
+	if err != nil {
+		return Profile{}, err
+	}
+	return profile, nil
+}
+
+func (s *Service) saveProfile(profileName string, profile Profile) error {
+	if s.Profiles == nil {
+		return nil
+	}
+	return s.Profiles.Upsert(strings.TrimSpace(profileName), profile)
+}
+
+func (s *Service) loadSecret(ref string) (string, error) {
+	if s.Secrets == nil {
+		return "", errors.New("secret store is required")
+	}
+	return s.Secrets.Get(ref)
+}
+
+func joinLinkedInPath(basePath string, childPath string) string {
+	basePath = strings.TrimSuffix(basePath, "/")
+	childPath = "/" + strings.TrimPrefix(childPath, "/")
+	return basePath + childPath
+}

--- a/internal/linkedin/auth_test.go
+++ b/internal/linkedin/auth_test.go
@@ -315,6 +315,100 @@ func TestSetupPersistsTokensAndWhoAmIWithStandardFlow(t *testing.T) {
 	}
 }
 
+func TestSetupStandardFlowAllowsHostedHTTPSRedirectOverride(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+
+	profileName := "prod"
+	err := profiles.Upsert(profileName, Profile{
+		Provider:        ProviderLinkedIn,
+		LinkedInVersion: "202602",
+		ClientID:        "client-123",
+		ClientSecretRef: "secret-ref",
+		AccessTokenRef:  "access-ref",
+		RefreshTokenRef: "refresh-ref",
+		Scopes:          []string{"r_ads"},
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("secret-ref", "secret-123"); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	originalState := newState
+	originalListener := newListener
+	originalBrowser := openBrowser
+	defer func() {
+		newState = originalState
+		newListener = originalListener
+		openBrowser = originalBrowser
+	}()
+
+	openBrowser = func(string) error {
+		t.Fatal("unexpected browser open")
+		return nil
+	}
+	newState = func() (string, error) {
+		return "state-123", nil
+	}
+
+	listener := &fakeOAuthListener{redirectURI: "http://127.0.0.1:3456/oauth/callback", code: "auth-code"}
+	newListener = func(redirectURI string, state string) (oauthCodeListener, error) {
+		if redirectURI != "http://127.0.0.1:3456/oauth/callback" {
+			t.Fatalf("unexpected listener redirect uri: %s", redirectURI)
+		}
+		if state != "state-123" {
+			t.Fatalf("unexpected state: %s", state)
+		}
+		return listener, nil
+	}
+
+	var announcedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/v2/accessToken":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.PostForm.Get("redirect_uri"); got != "https://meta.example.com/li/oauth/callback" {
+				t.Fatalf("unexpected redirect_uri: %s", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"access-123","expires_in":3600,"refresh_token":"refresh-123","refresh_token_expires_in":7200,"scope":"r_ads"}`))
+		case "/v2/me":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"urn:li:person:abc","localizedFirstName":"Ada","localizedLastName":"Lovelace"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(server.Client(), server.URL, server.URL, profiles, secrets)
+	result, err := svc.Setup(context.Background(), profileName, SetupInput{
+		ListenerURI: "http://127.0.0.1:3456/oauth/callback",
+		RedirectURI: "https://meta.example.com/li/oauth/callback",
+		Scopes:      []string{"r_ads"},
+		AuthFlow:    string(AuthFlowStandard),
+		OnAuthURL: func(raw string) {
+			announcedURL = raw
+		},
+		OpenBrowser: false,
+		Timeout:     time.Second,
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if !strings.Contains(announcedURL, "redirect_uri=https%3A%2F%2Fmeta.example.com%2Fli%2Foauth%2Fcallback") {
+		t.Fatalf("unexpected authorization url: %s", announcedURL)
+	}
+	if result.RedirectURI != "https://meta.example.com/li/oauth/callback" {
+		t.Fatalf("unexpected result redirect uri: %s", result.RedirectURI)
+	}
+}
+
 func TestSetupNativePKCEUsesCodeVerifierExchange(t *testing.T) {
 	profiles := newMemoryProfileStore()
 	secrets := newMemorySecretStore()
@@ -406,6 +500,41 @@ func TestSetupNativePKCEUsesCodeVerifierExchange(t *testing.T) {
 	}
 	if result.AuthFlow != string(AuthFlowNativePKCE) {
 		t.Fatalf("unexpected auth flow: %s", result.AuthFlow)
+	}
+}
+
+func TestSetupRejectsNonLoopbackHTTPRedirectForStandardFlow(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+
+	err := profiles.Upsert("prod", Profile{
+		Provider:        ProviderLinkedIn,
+		LinkedInVersion: "202602",
+		ClientID:        "client-123",
+		ClientSecretRef: "secret-ref",
+		AccessTokenRef:  "access-ref",
+		RefreshTokenRef: "refresh-ref",
+		Scopes:          []string{"r_ads"},
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("secret-ref", "secret-123"); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	svc := NewService(nil, DefaultAuthBaseURL, DefaultAPIBaseURL, profiles, secrets)
+	_, err = svc.Setup(context.Background(), "prod", SetupInput{
+		ListenerURI: "http://127.0.0.1:3456/oauth/callback",
+		RedirectURI: "http://meta.example.com/li/oauth/callback",
+		AuthFlow:    string(AuthFlowStandard),
+		Timeout:     time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected redirect uri validation error")
+	}
+	if !strings.Contains(err.Error(), "standard flow requires https or loopback http") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/linkedin/auth_test.go
+++ b/internal/linkedin/auth_test.go
@@ -1,0 +1,504 @@
+package linkedin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type memoryProfileStore struct {
+	mu       sync.Mutex
+	profiles map[string]Profile
+}
+
+func newMemoryProfileStore() *memoryProfileStore {
+	return &memoryProfileStore{profiles: map[string]Profile{}}
+}
+
+func (m *memoryProfileStore) Get(name string) (Profile, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	profile, ok := m.profiles[name]
+	if !ok {
+		return Profile{}, fmt.Errorf("profile not found: %s", name)
+	}
+	return profile, nil
+}
+
+func (m *memoryProfileStore) Upsert(name string, profile Profile) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.profiles[name] = profile
+	return nil
+}
+
+type memorySecretStore struct {
+	mu      sync.Mutex
+	secrets map[string]string
+}
+
+func newMemorySecretStore() *memorySecretStore {
+	return &memorySecretStore{secrets: map[string]string{}}
+}
+
+func (m *memorySecretStore) Set(ref string, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secrets[ref] = value
+	return nil
+}
+
+func (m *memorySecretStore) Get(ref string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	value, ok := m.secrets[ref]
+	if !ok {
+		return "", fmt.Errorf("secret not found: %s", ref)
+	}
+	return value, nil
+}
+
+type fakeOAuthListener struct {
+	redirectURI string
+	state       string
+	code        string
+	err         error
+	closed      bool
+}
+
+func (f *fakeOAuthListener) RedirectURI() string { return f.redirectURI }
+func (f *fakeOAuthListener) Wait(_ context.Context, _ time.Duration) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.code, nil
+}
+func (f *fakeOAuthListener) Close(_ context.Context) error {
+	f.closed = true
+	return nil
+}
+
+func TestBuildAuthorizationURLIncludesStateAndScopes(t *testing.T) {
+	t.Parallel()
+
+	raw, err := buildAuthorizationURL(
+		DefaultAuthBaseURL,
+		"client-123",
+		"http://127.0.0.1:3456/callback",
+		[]string{"r_ads", "r_basicprofile"},
+		"challenge-123",
+		"state-123",
+	)
+	if err != nil {
+		t.Fatalf("build authorization url: %v", err)
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse authorization url: %v", err)
+	}
+	if parsed.Path != "/oauth/native-pkce/authorization" {
+		t.Fatalf("unexpected path: %s", parsed.Path)
+	}
+
+	query := parsed.Query()
+	if got := query.Get("response_type"); got != "code" {
+		t.Fatalf("unexpected response_type: %s", got)
+	}
+	if got := query.Get("client_id"); got != "client-123" {
+		t.Fatalf("unexpected client_id: %s", got)
+	}
+	if got := query.Get("redirect_uri"); got != "http://127.0.0.1:3456/callback" {
+		t.Fatalf("unexpected redirect_uri: %s", got)
+	}
+	if got := query.Get("state"); got != "state-123" {
+		t.Fatalf("unexpected state: %s", got)
+	}
+	if got := query.Get("code_challenge"); got != "challenge-123" {
+		t.Fatalf("unexpected code_challenge: %s", got)
+	}
+	if got := query.Get("code_challenge_method"); got != "S256" {
+		t.Fatalf("unexpected code_challenge_method: %s", got)
+	}
+	if got := query.Get("scope"); got != "r_ads r_basicprofile" {
+		t.Fatalf("unexpected scope: %s", got)
+	}
+}
+
+func TestSetupPersistsTokensAndWhoAmI(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+
+	profileName := "prod"
+	err := profiles.Upsert(profileName, Profile{
+		Provider:        ProviderLinkedIn,
+		LinkedInVersion: "202602",
+		ClientID:        "client-123",
+		ClientSecretRef: "secret-ref",
+		AccessTokenRef:  "access-ref",
+		RefreshTokenRef: "refresh-ref",
+		Scopes:          []string{"r_ads"},
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("secret-ref", "secret-123"); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	originalPKCE := newPKCE
+	originalState := newState
+	originalListener := newListener
+	originalBrowser := openBrowser
+	defer func() {
+		newPKCE = originalPKCE
+		newState = originalState
+		newListener = originalListener
+		openBrowser = originalBrowser
+	}()
+
+	newPKCE = func() (string, string, error) {
+		return "verifier-123", "challenge-123", nil
+	}
+	newState = func() (string, error) {
+		return "state-123", nil
+	}
+
+	listener := &fakeOAuthListener{redirectURI: "http://127.0.0.1:3456/callback", code: "auth-code"}
+	var openedURL string
+	newListener = func(redirectURI string, state string) (oauthCodeListener, error) {
+		if redirectURI != "http://127.0.0.1:3456/callback" {
+			t.Fatalf("unexpected redirect uri: %s", redirectURI)
+		}
+		if state != "state-123" {
+			t.Fatalf("unexpected state: %s", state)
+		}
+		return listener, nil
+	}
+	openBrowser = func(raw string) error {
+		openedURL = raw
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/v2/accessToken":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+			if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+				t.Fatalf("unexpected content-type: %s", got)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.PostForm.Get("grant_type"); got != "authorization_code" {
+				t.Fatalf("unexpected grant_type: %s", got)
+			}
+			if got := r.PostForm.Get("code"); got != "auth-code" {
+				t.Fatalf("unexpected code: %s", got)
+			}
+			if got := r.PostForm.Get("redirect_uri"); got != "http://127.0.0.1:3456/callback" {
+				t.Fatalf("unexpected redirect_uri: %s", got)
+			}
+			if got := r.PostForm.Get("client_id"); got != "client-123" {
+				t.Fatalf("unexpected client_id: %s", got)
+			}
+			if got := r.PostForm.Get("code_verifier"); got != "verifier-123" {
+				t.Fatalf("unexpected code_verifier: %s", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"access-123","expires_in":3600,"refresh_token":"refresh-123","refresh_token_expires_in":7200,"scope":"r_ads r_basicprofile"}`))
+		case "/v2/me":
+			if got := r.Header.Get("Authorization"); got != "Bearer access-123" {
+				t.Fatalf("unexpected authorization header: %s", got)
+			}
+			if got := r.Header.Get("LinkedIn-Version"); got != "202602" {
+				t.Fatalf("unexpected LinkedIn-Version header: %s", got)
+			}
+			if got := r.Header.Get("X-Restli-Protocol-Version"); got != restLiProtocolVersion {
+				t.Fatalf("unexpected restli header: %s", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"urn:li:person:abc","localizedFirstName":"Ada","localizedLastName":"Lovelace"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(server.Client(), server.URL, server.URL, profiles, secrets)
+	result, err := svc.Setup(context.Background(), profileName, SetupInput{
+		RedirectURI: "http://127.0.0.1:3456/callback",
+		Scopes:      []string{"r_ads", "r_basicprofile"},
+		OpenBrowser: true,
+		Timeout:     time.Second,
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if openedURL == "" {
+		t.Fatal("expected browser to be opened")
+	}
+	if !strings.Contains(openedURL, "state=state-123") {
+		t.Fatalf("unexpected authorization url: %s", openedURL)
+	}
+
+	access, err := secrets.Get("access-ref")
+	if err != nil {
+		t.Fatalf("load access token: %v", err)
+	}
+	if access != "access-123" {
+		t.Fatalf("unexpected access token: %s", access)
+	}
+	refresh, err := secrets.Get("refresh-ref")
+	if err != nil {
+		t.Fatalf("load refresh token: %v", err)
+	}
+	if refresh != "refresh-123" {
+		t.Fatalf("unexpected refresh token: %s", refresh)
+	}
+
+	if result == nil || result.Token.AccessToken != "access-123" {
+		t.Fatalf("unexpected setup token result: %#v", result)
+	}
+	if result.WhoAmI == nil || result.WhoAmI.FullName != "Ada Lovelace" {
+		t.Fatalf("unexpected whoami result: %#v", result.WhoAmI)
+	}
+}
+
+func TestValidateRefreshesExpiredToken(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+
+	now := time.Now().UTC()
+	err := profiles.Upsert("prod", Profile{
+		Provider:              ProviderLinkedIn,
+		LinkedInVersion:       "202602",
+		ClientID:              "client-123",
+		ClientSecretRef:       "secret-ref",
+		AccessTokenRef:        "access-ref",
+		RefreshTokenRef:       "refresh-ref",
+		Scopes:                []string{"r_ads"},
+		AccessTokenExpiresAt:  now.Add(-1 * time.Hour),
+		RefreshTokenExpiresAt: now.Add(24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("access-ref", "expired-access"); err != nil {
+		t.Fatalf("seed access token: %v", err)
+	}
+	if err := secrets.Set("refresh-ref", "refresh-123"); err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+	if err := secrets.Set("secret-ref", "secret-123"); err != nil {
+		t.Fatalf("seed client secret: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/v2/accessToken":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.PostForm.Get("grant_type"); got != "refresh_token" {
+				t.Fatalf("unexpected grant_type: %s", got)
+			}
+			if got := r.PostForm.Get("refresh_token"); got != "refresh-123" {
+				t.Fatalf("unexpected refresh token: %s", got)
+			}
+			if got := r.PostForm.Get("client_id"); got != "client-123" {
+				t.Fatalf("unexpected client_id: %s", got)
+			}
+			if got := r.PostForm.Get("client_secret"); got != "secret-123" {
+				t.Fatalf("unexpected client_secret: %s", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fresh-access","expires_in":3600,"refresh_token":"fresh-refresh","refresh_token_expires_in":7200,"scope":"r_ads r_basicprofile"}`))
+		case "/v2/me":
+			if got := r.Header.Get("Authorization"); got != "Bearer fresh-access" {
+				t.Fatalf("unexpected authorization header: %s", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"urn:li:person:xyz","firstName":{"localized":{"en_US":"Grace"},"preferredLocale":{"language":"en","country":"US"}},"lastName":{"localized":{"en_US":"Hopper"},"preferredLocale":{"language":"en","country":"US"}}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(server.Client(), server.URL, server.URL, profiles, secrets)
+	result, err := svc.Validate(context.Background(), "prod")
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !result.Refreshed {
+		t.Fatal("expected token refresh")
+	}
+	if result.Token.AccessToken != "fresh-access" {
+		t.Fatalf("unexpected refreshed access token: %s", result.Token.AccessToken)
+	}
+	if result.WhoAmI == nil || result.WhoAmI.FullName != "Grace Hopper" {
+		t.Fatalf("unexpected whoami: %#v", result.WhoAmI)
+	}
+
+	access, err := secrets.Get("access-ref")
+	if err != nil {
+		t.Fatalf("load updated access token: %v", err)
+	}
+	if access != "fresh-access" {
+		t.Fatalf("unexpected persisted access token: %s", access)
+	}
+	refresh, err := secrets.Get("refresh-ref")
+	if err != nil {
+		t.Fatalf("load updated refresh token: %v", err)
+	}
+	if refresh != "fresh-refresh" {
+		t.Fatalf("unexpected persisted refresh token: %s", refresh)
+	}
+	updatedProfile, err := profiles.Get("prod")
+	if err != nil {
+		t.Fatalf("load updated profile: %v", err)
+	}
+	if updatedProfile.AccessTokenExpiresAt.Before(now) {
+		t.Fatal("expected access token expiry to be updated")
+	}
+}
+
+func TestScopesReturnsStoredScopes(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+	err := profiles.Upsert("prod", Profile{
+		Provider:             ProviderLinkedIn,
+		LinkedInVersion:      "202602",
+		ClientID:             "client-123",
+		ClientSecretRef:      "secret-ref",
+		AccessTokenRef:       "access-ref",
+		RefreshTokenRef:      "refresh-ref",
+		Scopes:               []string{"r_ads", "r_basicprofile"},
+		AccessTokenExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("access-ref", "access-123"); err != nil {
+		t.Fatalf("seed access token: %v", err)
+	}
+
+	svc := NewService(&http.Client{Timeout: time.Second}, DefaultAPIBaseURL, DefaultAPIBaseURL, profiles, secrets)
+	scopes, err := svc.Scopes(context.Background(), "prod")
+	if err != nil {
+		t.Fatalf("scopes: %v", err)
+	}
+	if len(scopes) != 2 || scopes[0] != "r_ads" || scopes[1] != "r_basicprofile" {
+		t.Fatalf("unexpected scopes: %#v", scopes)
+	}
+}
+
+func TestClassifyLinkedInErrorCategories(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		wantCat ErrorCategory
+	}{
+		{
+			name:    "validation",
+			status:  http.StatusBadRequest,
+			body:    `{"error":"invalid_request","error_description":"missing client_id"}`,
+			wantCat: ErrorCategoryValidation,
+		},
+		{
+			name:    "auth",
+			status:  http.StatusUnauthorized,
+			body:    `{"message":"invalid token"}`,
+			wantCat: ErrorCategoryAuth,
+		},
+		{
+			name:    "permission",
+			status:  http.StatusForbidden,
+			body:    `{"message":"access denied"}`,
+			wantCat: ErrorCategoryPermission,
+		},
+		{
+			name:    "rate limit",
+			status:  http.StatusTooManyRequests,
+			body:    `{"message":"too many requests"}`,
+			wantCat: ErrorCategoryRateLimit,
+		},
+		{
+			name:    "version",
+			status:  http.StatusUpgradeRequired,
+			body:    `{"message":"unsupported version"}`,
+			wantCat: ErrorCategoryVersion,
+		},
+		{
+			name:    "not found",
+			status:  http.StatusNotFound,
+			body:    `{"message":"missing"}`,
+			wantCat: ErrorCategoryNotFound,
+		},
+		{
+			name:    "conflict",
+			status:  http.StatusConflict,
+			body:    `{"message":"conflict"}`,
+			wantCat: ErrorCategoryConflict,
+		},
+		{
+			name:    "transient",
+			status:  http.StatusInternalServerError,
+			body:    `{"message":"server error"}`,
+			wantCat: ErrorCategoryTransient,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := classifyLinkedInError(tc.status, []byte(tc.body))
+			var apiErr *Error
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected linked in error, got %T", err)
+			}
+			if apiErr.Category != tc.wantCat {
+				t.Fatalf("unexpected category: got=%s want=%s", apiErr.Category, tc.wantCat)
+			}
+		})
+	}
+}
+
+func TestParseWhoAmISupportsLocalizedNames(t *testing.T) {
+	t.Parallel()
+
+	result := parseWhoAmI(map[string]any{
+		"id": "urn:li:person:abc",
+		"firstName": map[string]any{
+			"localized": map[string]any{"en_US": "Linus"},
+			"preferredLocale": map[string]any{
+				"language": "en",
+				"country":  "US",
+			},
+		},
+		"lastName": map[string]any{
+			"localized": map[string]any{"en_US": "Torvalds"},
+			"preferredLocale": map[string]any{
+				"language": "en",
+				"country":  "US",
+			},
+		},
+	})
+	if result.ID != "urn:li:person:abc" {
+		t.Fatalf("unexpected id: %s", result.ID)
+	}
+	if result.FullName != "Linus Torvalds" {
+		t.Fatalf("unexpected full name: %s", result.FullName)
+	}
+}

--- a/internal/linkedin/auth_test.go
+++ b/internal/linkedin/auth_test.go
@@ -538,6 +538,69 @@ func TestSetupRejectsNonLoopbackHTTPRedirectForStandardFlow(t *testing.T) {
 	}
 }
 
+func TestSetupSkipsWhoAmIWithoutIdentityScopes(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+
+	profileName := "prod"
+	err := profiles.Upsert(profileName, Profile{
+		Provider:        ProviderLinkedIn,
+		LinkedInVersion: "202603",
+		ClientID:        "client-123",
+		ClientSecretRef: "secret-ref",
+		AccessTokenRef:  "access-ref",
+		RefreshTokenRef: "refresh-ref",
+		Scopes:          []string{"r_ads", "rw_ads", "r_ads_reporting"},
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("secret-ref", "secret-123"); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	originalState := newState
+	originalListener := newListener
+	defer func() {
+		newState = originalState
+		newListener = originalListener
+	}()
+	newState = func() (string, error) { return "state-123", nil }
+	newListener = func(redirectURI string, state string) (oauthCodeListener, error) {
+		return &fakeOAuthListener{redirectURI: redirectURI, state: state, code: "auth-code"}, nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/v2/accessToken":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"access-123","expires_in":3600,"refresh_token":"refresh-123","refresh_token_expires_in":7200,"scope":"r_ads rw_ads r_ads_reporting"}`))
+		case "/v2/me":
+			t.Fatal("whoami should be skipped for ads-only scopes")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(server.Client(), server.URL, server.URL, profiles, secrets)
+	result, err := svc.Setup(context.Background(), profileName, SetupInput{
+		RedirectURI: "http://127.0.0.1:3456/callback",
+		Scopes:      []string{"r_ads", "rw_ads", "r_ads_reporting"},
+		OpenBrowser: false,
+		Timeout:     time.Second,
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if result.WhoAmI != nil {
+		t.Fatalf("expected whoami to be nil, got %#v", result.WhoAmI)
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "r_liteprofile") {
+		t.Fatalf("unexpected warnings: %#v", result.Warnings)
+	}
+}
+
 func TestValidateRefreshesExpiredToken(t *testing.T) {
 	profiles := newMemoryProfileStore()
 	secrets := newMemorySecretStore()
@@ -634,6 +697,52 @@ func TestValidateRefreshesExpiredToken(t *testing.T) {
 	}
 	if updatedProfile.AccessTokenExpiresAt.Before(now) {
 		t.Fatal("expected access token expiry to be updated")
+	}
+}
+
+func TestValidateSuppressesWhoAmIPermissionError(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+
+	err := profiles.Upsert("prod", Profile{
+		Provider:             ProviderLinkedIn,
+		LinkedInVersion:      "202603",
+		ClientID:             "client-123",
+		ClientSecretRef:      "secret-ref",
+		AccessTokenRef:       "access-ref",
+		RefreshTokenRef:      "refresh-ref",
+		Scopes:               []string{"r_ads", "r_liteprofile"},
+		AccessTokenExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("access-ref", "access-123"); err != nil {
+		t.Fatalf("seed access token: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/me":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Not enough permissions to access: me.GET.NO_VERSION"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(server.Client(), server.URL, server.URL, profiles, secrets)
+	result, err := svc.Validate(context.Background(), "prod")
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if result.WhoAmI != nil {
+		t.Fatalf("expected whoami to be nil, got %#v", result.WhoAmI)
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "me.GET.NO_VERSION") {
+		t.Fatalf("unexpected warnings: %#v", result.Warnings)
 	}
 }
 

--- a/internal/linkedin/auth_test.go
+++ b/internal/linkedin/auth_test.go
@@ -195,12 +195,15 @@ func TestSetupPersistsTokensAndWhoAmIWithStandardFlow(t *testing.T) {
 		newListener = originalListener
 		openBrowser = originalBrowser
 	}()
+	openBrowser = func(string) error {
+		t.Fatal("unexpected browser open")
+		return nil
+	}
 	newState = func() (string, error) {
 		return "state-123", nil
 	}
 
 	listener := &fakeOAuthListener{redirectURI: "http://127.0.0.1:3456/callback", code: "auth-code"}
-	var openedURL string
 	newListener = func(redirectURI string, state string) (oauthCodeListener, error) {
 		if redirectURI != "http://127.0.0.1:3456/callback" {
 			t.Fatalf("unexpected redirect uri: %s", redirectURI)
@@ -210,10 +213,7 @@ func TestSetupPersistsTokensAndWhoAmIWithStandardFlow(t *testing.T) {
 		}
 		return listener, nil
 	}
-	openBrowser = func(raw string) error {
-		openedURL = raw
-		return nil
-	}
+	var announcedURL string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -269,21 +269,24 @@ func TestSetupPersistsTokensAndWhoAmIWithStandardFlow(t *testing.T) {
 	result, err := svc.Setup(context.Background(), profileName, SetupInput{
 		RedirectURI: "http://127.0.0.1:3456/callback",
 		Scopes:      []string{"r_ads", "r_basicprofile"},
-		OpenBrowser: true,
+		OnAuthURL: func(raw string) {
+			announcedURL = raw
+		},
+		OpenBrowser: false,
 		Timeout:     time.Second,
 	})
 	if err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 
-	if openedURL == "" {
-		t.Fatal("expected browser to be opened")
+	if announcedURL == "" {
+		t.Fatal("expected auth URL to be announced")
 	}
-	if !strings.Contains(openedURL, "/oauth/v2/authorization") {
-		t.Fatalf("unexpected authorization url: %s", openedURL)
+	if !strings.Contains(announcedURL, "/oauth/v2/authorization") {
+		t.Fatalf("unexpected authorization url: %s", announcedURL)
 	}
-	if !strings.Contains(openedURL, "state=state-123") {
-		t.Fatalf("unexpected authorization url: %s", openedURL)
+	if !strings.Contains(announcedURL, "state=state-123") {
+		t.Fatalf("unexpected authorization url: %s", announcedURL)
 	}
 
 	access, err := secrets.Get("access-ref")
@@ -352,12 +355,11 @@ func TestSetupNativePKCEUsesCodeVerifierExchange(t *testing.T) {
 	}
 
 	listener := &fakeOAuthListener{redirectURI: "http://127.0.0.1:3456/callback", code: "auth-code"}
-	var openedURL string
+	var announcedURL string
 	newListener = func(redirectURI string, state string) (oauthCodeListener, error) {
 		return listener, nil
 	}
 	openBrowser = func(raw string) error {
-		openedURL = raw
 		return nil
 	}
 
@@ -389,6 +391,9 @@ func TestSetupNativePKCEUsesCodeVerifierExchange(t *testing.T) {
 		RedirectURI: "http://127.0.0.1:3456/callback",
 		Scopes:      []string{"r_ads"},
 		AuthFlow:    string(AuthFlowNativePKCE),
+		OnAuthURL: func(raw string) {
+			announcedURL = raw
+		},
 		OpenBrowser: true,
 		Timeout:     time.Second,
 	})
@@ -396,8 +401,8 @@ func TestSetupNativePKCEUsesCodeVerifierExchange(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 
-	if !strings.Contains(openedURL, "/oauth/native-pkce/authorization") {
-		t.Fatalf("unexpected authorization url: %s", openedURL)
+	if !strings.Contains(announcedURL, "/oauth/native-pkce/authorization") {
+		t.Fatalf("unexpected authorization url: %s", announcedURL)
 	}
 	if result.AuthFlow != string(AuthFlowNativePKCE) {
 		t.Fatalf("unexpected auth flow: %s", result.AuthFlow)

--- a/internal/linkedin/auth_test.go
+++ b/internal/linkedin/auth_test.go
@@ -85,7 +85,7 @@ func (f *fakeOAuthListener) Close(_ context.Context) error {
 	return nil
 }
 
-func TestBuildAuthorizationURLIncludesStateAndScopes(t *testing.T) {
+func TestBuildAuthorizationURLStandardFlowIncludesStateAndScopes(t *testing.T) {
 	t.Parallel()
 
 	raw, err := buildAuthorizationURL(
@@ -93,8 +93,9 @@ func TestBuildAuthorizationURLIncludesStateAndScopes(t *testing.T) {
 		"client-123",
 		"http://127.0.0.1:3456/callback",
 		[]string{"r_ads", "r_basicprofile"},
-		"challenge-123",
+		"",
 		"state-123",
+		AuthFlowStandard,
 	)
 	if err != nil {
 		t.Fatalf("build authorization url: %v", err)
@@ -104,7 +105,7 @@ func TestBuildAuthorizationURLIncludesStateAndScopes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse authorization url: %v", err)
 	}
-	if parsed.Path != "/oauth/native-pkce/authorization" {
+	if parsed.Path != "/oauth/v2/authorization" {
 		t.Fatalf("unexpected path: %s", parsed.Path)
 	}
 
@@ -121,10 +122,10 @@ func TestBuildAuthorizationURLIncludesStateAndScopes(t *testing.T) {
 	if got := query.Get("state"); got != "state-123" {
 		t.Fatalf("unexpected state: %s", got)
 	}
-	if got := query.Get("code_challenge"); got != "challenge-123" {
+	if got := query.Get("code_challenge"); got != "" {
 		t.Fatalf("unexpected code_challenge: %s", got)
 	}
-	if got := query.Get("code_challenge_method"); got != "S256" {
+	if got := query.Get("code_challenge_method"); got != "" {
 		t.Fatalf("unexpected code_challenge_method: %s", got)
 	}
 	if got := query.Get("scope"); got != "r_ads r_basicprofile" {
@@ -132,7 +133,40 @@ func TestBuildAuthorizationURLIncludesStateAndScopes(t *testing.T) {
 	}
 }
 
-func TestSetupPersistsTokensAndWhoAmI(t *testing.T) {
+func TestBuildAuthorizationURLNativePKCEIncludesChallenge(t *testing.T) {
+	t.Parallel()
+
+	raw, err := buildAuthorizationURL(
+		DefaultAuthBaseURL,
+		"client-123",
+		"http://127.0.0.1:3456/callback",
+		[]string{"r_ads", "r_basicprofile"},
+		"challenge-123",
+		"state-123",
+		AuthFlowNativePKCE,
+	)
+	if err != nil {
+		t.Fatalf("build authorization url: %v", err)
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse authorization url: %v", err)
+	}
+	if parsed.Path != "/oauth/native-pkce/authorization" {
+		t.Fatalf("unexpected path: %s", parsed.Path)
+	}
+
+	query := parsed.Query()
+	if got := query.Get("code_challenge"); got != "challenge-123" {
+		t.Fatalf("unexpected code_challenge: %s", got)
+	}
+	if got := query.Get("code_challenge_method"); got != "S256" {
+		t.Fatalf("unexpected code_challenge_method: %s", got)
+	}
+}
+
+func TestSetupPersistsTokensAndWhoAmIWithStandardFlow(t *testing.T) {
 	profiles := newMemoryProfileStore()
 	secrets := newMemorySecretStore()
 
@@ -153,20 +187,14 @@ func TestSetupPersistsTokensAndWhoAmI(t *testing.T) {
 		t.Fatalf("seed secret: %v", err)
 	}
 
-	originalPKCE := newPKCE
 	originalState := newState
 	originalListener := newListener
 	originalBrowser := openBrowser
 	defer func() {
-		newPKCE = originalPKCE
 		newState = originalState
 		newListener = originalListener
 		openBrowser = originalBrowser
 	}()
-
-	newPKCE = func() (string, string, error) {
-		return "verifier-123", "challenge-123", nil
-	}
 	newState = func() (string, error) {
 		return "state-123", nil
 	}
@@ -211,7 +239,10 @@ func TestSetupPersistsTokensAndWhoAmI(t *testing.T) {
 			if got := r.PostForm.Get("client_id"); got != "client-123" {
 				t.Fatalf("unexpected client_id: %s", got)
 			}
-			if got := r.PostForm.Get("code_verifier"); got != "verifier-123" {
+			if got := r.PostForm.Get("client_secret"); got != "secret-123" {
+				t.Fatalf("unexpected client_secret: %s", got)
+			}
+			if got := r.PostForm.Get("code_verifier"); got != "" {
 				t.Fatalf("unexpected code_verifier: %s", got)
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -248,6 +279,9 @@ func TestSetupPersistsTokensAndWhoAmI(t *testing.T) {
 	if openedURL == "" {
 		t.Fatal("expected browser to be opened")
 	}
+	if !strings.Contains(openedURL, "/oauth/v2/authorization") {
+		t.Fatalf("unexpected authorization url: %s", openedURL)
+	}
 	if !strings.Contains(openedURL, "state=state-123") {
 		t.Fatalf("unexpected authorization url: %s", openedURL)
 	}
@@ -270,8 +304,103 @@ func TestSetupPersistsTokensAndWhoAmI(t *testing.T) {
 	if result == nil || result.Token.AccessToken != "access-123" {
 		t.Fatalf("unexpected setup token result: %#v", result)
 	}
+	if result.AuthFlow != string(AuthFlowStandard) {
+		t.Fatalf("unexpected auth flow: %s", result.AuthFlow)
+	}
 	if result.WhoAmI == nil || result.WhoAmI.FullName != "Ada Lovelace" {
 		t.Fatalf("unexpected whoami result: %#v", result.WhoAmI)
+	}
+}
+
+func TestSetupNativePKCEUsesCodeVerifierExchange(t *testing.T) {
+	profiles := newMemoryProfileStore()
+	secrets := newMemorySecretStore()
+
+	profileName := "prod"
+	err := profiles.Upsert(profileName, Profile{
+		Provider:        ProviderLinkedIn,
+		LinkedInVersion: "202602",
+		ClientID:        "client-123",
+		ClientSecretRef: "secret-ref",
+		AccessTokenRef:  "access-ref",
+		RefreshTokenRef: "refresh-ref",
+		Scopes:          []string{"r_ads"},
+	})
+	if err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if err := secrets.Set("secret-ref", "secret-123"); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	originalPKCE := newPKCE
+	originalState := newState
+	originalListener := newListener
+	originalBrowser := openBrowser
+	defer func() {
+		newPKCE = originalPKCE
+		newState = originalState
+		newListener = originalListener
+		openBrowser = originalBrowser
+	}()
+
+	newPKCE = func() (string, string, error) {
+		return "verifier-123", "challenge-123", nil
+	}
+	newState = func() (string, error) {
+		return "state-123", nil
+	}
+
+	listener := &fakeOAuthListener{redirectURI: "http://127.0.0.1:3456/callback", code: "auth-code"}
+	var openedURL string
+	newListener = func(redirectURI string, state string) (oauthCodeListener, error) {
+		return listener, nil
+	}
+	openBrowser = func(raw string) error {
+		openedURL = raw
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/v2/accessToken":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.PostForm.Get("code_verifier"); got != "verifier-123" {
+				t.Fatalf("unexpected code_verifier: %s", got)
+			}
+			if got := r.PostForm.Get("client_secret"); got != "" {
+				t.Fatalf("unexpected client_secret: %s", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"access-123","expires_in":3600,"scope":"r_ads"}`))
+		case "/v2/me":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"urn:li:person:abc","localizedFirstName":"Ada","localizedLastName":"Lovelace"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(server.Client(), server.URL, server.URL, profiles, secrets)
+	result, err := svc.Setup(context.Background(), profileName, SetupInput{
+		RedirectURI: "http://127.0.0.1:3456/callback",
+		Scopes:      []string{"r_ads"},
+		AuthFlow:    string(AuthFlowNativePKCE),
+		OpenBrowser: true,
+		Timeout:     time.Second,
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if !strings.Contains(openedURL, "/oauth/native-pkce/authorization") {
+		t.Fatalf("unexpected authorization url: %s", openedURL)
+	}
+	if result.AuthFlow != string(AuthFlowNativePKCE) {
+		t.Fatalf("unexpected auth flow: %s", result.AuthFlow)
 	}
 }
 

--- a/internal/linkedin/client.go
+++ b/internal/linkedin/client.go
@@ -1,0 +1,551 @@
+package linkedin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultBaseURL              = "https://api.linkedin.com"
+	DefaultVersionHeader        = "Linkedin-Version"
+	DefaultRestliProtocolHeader = "X-Restli-Protocol-Version"
+	DefaultRestliProtocol       = "2.0.0"
+	DefaultUserAgent            = "meta-marketing-cli/linkedin"
+	DefaultQueryTunnelThreshold = 1800
+	DefaultPageSizeParam        = "pageSize"
+	DefaultPageTokenParam       = "pageToken"
+)
+
+type Client struct {
+	BaseURL               string
+	HTTP                  HTTPClient
+	UserAgent             string
+	Version               string
+	AccessToken           string
+	RestliProtocolVersion string
+	QueryTunnelThreshold  int
+	EnableQueryTunneling  bool
+	DefaultHeaders        map[string]string
+}
+
+type Request struct {
+	Method              string
+	Path                string
+	Version             string
+	Query               map[string]string
+	Headers             map[string]string
+	AccessToken         string
+	JSONBody            any
+	FormBody            map[string]string
+	AllowQueryTunneling bool
+}
+
+type Response struct {
+	StatusCode int
+	Headers    http.Header
+	Raw        []byte
+	Body       any
+}
+
+type CursorPaginationOptions struct {
+	PageSizeParam  string
+	PageTokenParam string
+	PageSize       int
+	PageToken      string
+}
+
+type CursorPaginationResult struct {
+	Pages         int    `json:"pages"`
+	NextPageToken string `json:"next_page_token,omitempty"`
+}
+
+type PaginationOptions struct {
+	FollowNext bool
+	Limit      int
+	PageSize   int
+	PageToken  string
+}
+
+type PagingInfo struct {
+	Pages         int    `json:"pages,omitempty"`
+	NextPageToken string `json:"next_page_token,omitempty"`
+}
+
+type CollectionResult struct {
+	Elements []map[string]any `json:"elements"`
+	Paging   *PagingInfo      `json:"paging,omitempty"`
+}
+
+func NewClient(httpClient HTTPClient, baseURL string, version string, accessToken string) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = DefaultBaseURL
+	}
+	return &Client{
+		BaseURL:               strings.TrimSuffix(baseURL, "/"),
+		HTTP:                  httpClient,
+		UserAgent:             DefaultUserAgent,
+		Version:               strings.TrimSpace(version),
+		AccessToken:           strings.TrimSpace(accessToken),
+		RestliProtocolVersion: DefaultRestliProtocol,
+		QueryTunnelThreshold:  DefaultQueryTunnelThreshold,
+		EnableQueryTunneling:  true,
+	}
+}
+
+func (c *Client) Do(ctx context.Context, req Request) (*Response, error) {
+	method := strings.ToUpper(strings.TrimSpace(req.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+	if strings.TrimSpace(req.Path) == "" {
+		return nil, errors.New("linkedin request path is required")
+	}
+
+	version := strings.TrimSpace(req.Version)
+	if version == "" {
+		version = strings.TrimSpace(c.Version)
+	}
+	if err := ValidateVersion(version); err != nil {
+		return nil, err
+	}
+
+	endpoint, err := c.buildEndpoint(req.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	query := cloneStringMap(req.Query)
+	if query == nil {
+		query = map[string]string{}
+	}
+
+	overrideMethod := ""
+	if c.shouldTunnel(method, query, req.AllowQueryTunneling) {
+		overrideMethod = method
+		method = http.MethodPost
+	}
+
+	body, contentType, err := c.buildBody(method, req, query, overrideMethod != "")
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint.RawQuery = buildQuery(query)
+	httpReq, err := http.NewRequestWithContext(ctx, method, endpoint.String(), body)
+	if err != nil {
+		return nil, fmt.Errorf("build linkedin request: %w", err)
+	}
+	c.applyHeaders(httpReq, req, version, contentType, overrideMethod)
+
+	httpRes, err := c.httpClient().Do(httpReq)
+	if err != nil {
+		return nil, &Error{
+			Category:  ErrorCategoryTransient,
+			Message:   fmt.Sprintf("send request: %v", err),
+			Retryable: true,
+		}
+	}
+	defer httpRes.Body.Close()
+
+	raw, err := io.ReadAll(httpRes.Body)
+	if err != nil {
+		return nil, &Error{
+			Category:   ErrorCategoryTransient,
+			StatusCode: httpRes.StatusCode,
+			Message:    fmt.Sprintf("read response: %v", err),
+			Retryable:  true,
+		}
+	}
+
+	var decoded any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return nil, fmt.Errorf("decode linkedin response JSON: %w", err)
+		}
+	}
+
+	if httpRes.StatusCode < 200 || httpRes.StatusCode >= 300 {
+		return nil, parseAPIError(httpRes.StatusCode, decoded, httpRes.Header, raw)
+	}
+
+	return &Response{
+		StatusCode: httpRes.StatusCode,
+		Headers:    httpRes.Header.Clone(),
+		Raw:        raw,
+		Body:       decoded,
+	}, nil
+}
+
+func (c *Client) CursorPages(ctx context.Context, req Request, opts CursorPaginationOptions, fn func(*Response, string) error) (*CursorPaginationResult, error) {
+	if fn == nil {
+		return nil, errors.New("cursor page callback is required")
+	}
+
+	current := cloneRequest(req)
+	if current.Query == nil {
+		current.Query = map[string]string{}
+	}
+	pageSizeKey := normalizePaginationKey(opts.PageSizeParam, DefaultPageSizeParam)
+	pageTokenKey := normalizePaginationKey(opts.PageTokenParam, DefaultPageTokenParam)
+	if opts.PageSize > 0 {
+		current.Query[pageSizeKey] = strconv.Itoa(opts.PageSize)
+	}
+	if strings.TrimSpace(opts.PageToken) != "" {
+		current.Query[pageTokenKey] = strings.TrimSpace(opts.PageToken)
+	}
+
+	result := &CursorPaginationResult{}
+	for {
+		resp, err := c.Do(ctx, current)
+		if err != nil {
+			return nil, err
+		}
+		result.Pages++
+
+		nextPageToken := ExtractNextPageToken(resp.Body)
+		if err := fn(resp, nextPageToken); err != nil {
+			return nil, err
+		}
+		result.NextPageToken = nextPageToken
+		if nextPageToken == "" {
+			return result, nil
+		}
+		current.Query[pageTokenKey] = nextPageToken
+	}
+}
+
+func (c *Client) FetchCollection(ctx context.Context, req Request, opts PaginationOptions, visit func(map[string]any) error) (*PagingInfo, error) {
+	if visit == nil {
+		return nil, errors.New("collection visit callback is required")
+	}
+	current := cloneRequest(req)
+	if current.Query == nil {
+		current.Query = map[string]string{}
+	}
+	pageSizeKey := normalizePaginationKey(DefaultPageSizeParam, DefaultPageSizeParam)
+	pageTokenKey := normalizePaginationKey(DefaultPageTokenParam, DefaultPageTokenParam)
+	if opts.PageSize > 0 {
+		current.Query[pageSizeKey] = strconv.Itoa(opts.PageSize)
+	}
+	if strings.TrimSpace(opts.PageToken) != "" {
+		current.Query[pageTokenKey] = strings.TrimSpace(opts.PageToken)
+	}
+
+	result := &PagingInfo{}
+	remaining := opts.Limit
+	for {
+		resp, err := c.Do(ctx, current)
+		if err != nil {
+			return nil, err
+		}
+		result.Pages++
+
+		elements, err := decodeCollectionElements(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		for _, element := range elements {
+			if err := visit(element); err != nil {
+				return nil, err
+			}
+			if remaining > 0 {
+				remaining--
+				if remaining == 0 {
+					result.NextPageToken = ExtractNextPageToken(resp.Body)
+					return result, nil
+				}
+			}
+		}
+
+		nextPageToken := ExtractNextPageToken(resp.Body)
+		result.NextPageToken = nextPageToken
+		if !opts.FollowNext || nextPageToken == "" {
+			return result, nil
+		}
+		current.Query[pageTokenKey] = nextPageToken
+	}
+}
+
+func (c *Client) buildEndpoint(rawPath string) (*url.URL, error) {
+	base, err := url.Parse(strings.TrimSpace(c.BaseURL))
+	if err != nil {
+		return nil, fmt.Errorf("parse linkedin base url: %w", err)
+	}
+	base.Path = path.Join(base.Path, strings.TrimPrefix(strings.TrimSpace(rawPath), "/"))
+	return base, nil
+}
+
+func (c *Client) shouldTunnel(method string, query map[string]string, requestTunnel bool) bool {
+	if method != http.MethodGet && method != http.MethodDelete {
+		return false
+	}
+	if len(query) == 0 {
+		return false
+	}
+	if !(c.EnableQueryTunneling || requestTunnel) {
+		return false
+	}
+	encoded := buildQuery(query)
+	threshold := c.QueryTunnelThreshold
+	if threshold <= 0 {
+		threshold = DefaultQueryTunnelThreshold
+	}
+	return len(encoded) > threshold
+}
+
+func (c *Client) buildBody(method string, req Request, query map[string]string, tunneled bool) (io.Reader, string, error) {
+	if req.JSONBody != nil && len(req.FormBody) > 0 {
+		return nil, "", errors.New("linkedin request cannot use both JSON body and form body")
+	}
+	if tunneled && req.JSONBody != nil {
+		return nil, "", errors.New("linkedin query tunneling is only supported for form bodies")
+	}
+
+	if tunneled {
+		form := cloneStringMap(req.FormBody)
+		if form == nil {
+			form = map[string]string{}
+		}
+		for key, value := range query {
+			form[key] = value
+		}
+		return strings.NewReader(encodeForm(form)), "application/x-www-form-urlencoded", nil
+	}
+
+	switch {
+	case len(req.FormBody) > 0:
+		return strings.NewReader(encodeForm(req.FormBody)), "application/x-www-form-urlencoded", nil
+	case req.JSONBody != nil:
+		raw, err := json.Marshal(req.JSONBody)
+		if err != nil {
+			return nil, "", fmt.Errorf("encode linkedin request JSON: %w", err)
+		}
+		return bytes.NewReader(raw), "application/json", nil
+	case method == http.MethodPost || method == http.MethodDelete:
+		return bytes.NewReader(nil), "", nil
+	default:
+		return nil, "", nil
+	}
+}
+
+func (c *Client) applyHeaders(req *http.Request, input Request, version string, contentType string, overrideMethod string) {
+	if req == nil {
+		return
+	}
+
+	for key, value := range c.DefaultHeaders {
+		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
+	for key, value := range input.Headers {
+		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	if strings.TrimSpace(c.UserAgent) == "" {
+		req.Header.Set("User-Agent", DefaultUserAgent)
+	} else {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	protocol := strings.TrimSpace(c.RestliProtocolVersion)
+	if protocol == "" {
+		protocol = DefaultRestliProtocol
+	}
+	req.Header.Set(DefaultRestliProtocolHeader, protocol)
+	if strings.TrimSpace(version) != "" {
+		req.Header.Set(DefaultVersionHeader, version)
+	}
+	token := strings.TrimSpace(input.AccessToken)
+	if token == "" {
+		token = strings.TrimSpace(c.AccessToken)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if overrideMethod != "" {
+		req.Header.Set("X-HTTP-Method-Override", overrideMethod)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+}
+
+func (c *Client) httpClient() HTTPClient {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func cloneRequest(req Request) Request {
+	clone := req
+	clone.Query = cloneStringMap(req.Query)
+	clone.Headers = cloneStringMap(req.Headers)
+	clone.FormBody = cloneStringMap(req.FormBody)
+	return clone
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func buildQuery(values map[string]string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	query := url.Values{}
+	for _, key := range keys {
+		query.Set(key, values[key])
+	}
+	return query.Encode()
+}
+
+func encodeForm(values map[string]string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	form := url.Values{}
+	for _, key := range keys {
+		form.Set(key, values[key])
+	}
+	return form.Encode()
+}
+
+func normalizePaginationKey(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func ExtractNextPageToken(body any) string {
+	switch typed := body.(type) {
+	case map[string]any:
+		return cursorTokenFromMap(typed)
+	default:
+		return ""
+	}
+}
+
+func cursorTokenFromMap(payload map[string]any) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	for _, key := range []string{"nextPageToken", "next_page_token"} {
+		if token, ok := payload[key].(string); ok && strings.TrimSpace(token) != "" {
+			return strings.TrimSpace(token)
+		}
+	}
+	for _, key := range []string{"paging", "metadata"} {
+		child, ok := payload[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, tokenKey := range []string{"nextPageToken", "pageToken", "next_page_token"} {
+			if token, ok := child[tokenKey].(string); ok && strings.TrimSpace(token) != "" {
+				return strings.TrimSpace(token)
+			}
+		}
+		if links, ok := child["links"].([]any); ok {
+			for _, raw := range links {
+				link, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				if rel, _ := link["rel"].(string); strings.EqualFold(strings.TrimSpace(rel), "next") {
+					if href, _ := link["href"].(string); strings.TrimSpace(href) != "" {
+						if token := tokenFromNextHref(href); token != "" {
+							return token
+						}
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func tokenFromNextHref(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	for _, key := range []string{"pageToken", "page_token", "page"} {
+		if token := strings.TrimSpace(parsed.Query().Get(key)); token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+func decodeCollectionElements(body any) ([]map[string]any, error) {
+	switch typed := body.(type) {
+	case map[string]any:
+		elementsRaw, ok := typed["elements"]
+		if !ok {
+			return nil, errors.New("collection response missing elements")
+		}
+		elementsAny, ok := elementsRaw.([]any)
+		if !ok {
+			return nil, errors.New("collection response elements must be an array")
+		}
+		elements := make([]map[string]any, 0, len(elementsAny))
+		for _, raw := range elementsAny {
+			element, ok := raw.(map[string]any)
+			if !ok {
+				return nil, errors.New("collection response element must be an object")
+			}
+			elements = append(elements, element)
+		}
+		return elements, nil
+	case []any:
+		elements := make([]map[string]any, 0, len(typed))
+		for _, raw := range typed {
+			element, ok := raw.(map[string]any)
+			if !ok {
+				return nil, errors.New("collection response element must be an object")
+			}
+			elements = append(elements, element)
+		}
+		return elements, nil
+	default:
+		return nil, errors.New("collection response must be an object or array")
+	}
+}

--- a/internal/linkedin/client.go
+++ b/internal/linkedin/client.go
@@ -424,11 +424,11 @@ func buildQuery(values map[string]string) string {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	query := url.Values{}
+	parts := make([]string, 0, len(keys))
 	for _, key := range keys {
-		query.Set(key, values[key])
+		parts = append(parts, encodeQueryPair(key, values[key]))
 	}
-	return query.Encode()
+	return strings.Join(parts, "&")
 }
 
 func encodeForm(values map[string]string) string {
@@ -440,12 +440,26 @@ func encodeForm(values map[string]string) string {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	form := url.Values{}
+	parts := make([]string, 0, len(keys))
 	for _, key := range keys {
-		form.Set(key, values[key])
+		parts = append(parts, encodeQueryPair(key, values[key]))
 	}
-	return form.Encode()
+	return strings.Join(parts, "&")
 }
+
+func encodeQueryPair(key string, value string) string {
+	escapedKey := url.QueryEscape(key)
+	escapedValue := url.QueryEscape(value)
+	escapedValue = restliValueEscaper.Replace(escapedValue)
+	return escapedKey + "=" + escapedValue
+}
+
+var restliValueEscaper = strings.NewReplacer(
+	"%28", "(",
+	"%29", ")",
+	"%2C", ",",
+	"%3A", ":",
+)
 
 func normalizePaginationKey(value string, fallback string) string {
 	value = strings.TrimSpace(value)

--- a/internal/linkedin/client.go
+++ b/internal/linkedin/client.go
@@ -25,6 +25,8 @@ const (
 	DefaultQueryTunnelThreshold = 1800
 	DefaultPageSizeParam        = "pageSize"
 	DefaultPageTokenParam       = "pageToken"
+	DefaultOffsetCountParam     = "count"
+	DefaultOffsetStartParam     = "start"
 )
 
 type Client struct {
@@ -71,10 +73,12 @@ type CursorPaginationResult struct {
 }
 
 type PaginationOptions struct {
-	FollowNext bool
-	Limit      int
-	PageSize   int
-	PageToken  string
+	FollowNext     bool
+	Limit          int
+	PageSize       int
+	PageToken      string
+	PageSizeParam  string
+	PageTokenParam string
 }
 
 type PagingInfo struct {
@@ -179,7 +183,7 @@ func (c *Client) Do(ctx context.Context, req Request) (*Response, error) {
 	}
 
 	if httpRes.StatusCode < 200 || httpRes.StatusCode >= 300 {
-		return nil, parseAPIError(httpRes.StatusCode, decoded, httpRes.Header, raw)
+		return nil, annotateRequestError(parseAPIError(httpRes.StatusCode, decoded, httpRes.Header, raw), httpReq)
 	}
 
 	return &Response{
@@ -236,8 +240,8 @@ func (c *Client) FetchCollection(ctx context.Context, req Request, opts Paginati
 	if current.Query == nil {
 		current.Query = map[string]string{}
 	}
-	pageSizeKey := normalizePaginationKey(DefaultPageSizeParam, DefaultPageSizeParam)
-	pageTokenKey := normalizePaginationKey(DefaultPageTokenParam, DefaultPageTokenParam)
+	pageSizeKey := normalizePaginationKey(opts.PageSizeParam, DefaultPageSizeParam)
+	pageTokenKey := normalizePaginationKey(opts.PageTokenParam, DefaultPageTokenParam)
 	if opts.PageSize > 0 {
 		current.Query[pageSizeKey] = strconv.Itoa(opts.PageSize)
 	}
@@ -512,6 +516,9 @@ func cursorTokenFromMap(payload map[string]any) string {
 				}
 			}
 		}
+		if token := offsetTokenFromPaging(child); token != "" {
+			return token
+		}
 	}
 	return ""
 }
@@ -526,7 +533,69 @@ func tokenFromNextHref(raw string) string {
 			return token
 		}
 	}
+	if token := strings.TrimSpace(parsed.Query().Get(DefaultOffsetStartParam)); token != "" {
+		return token
+	}
 	return ""
+}
+
+func offsetTokenFromPaging(payload map[string]any) string {
+	start, ok := numericField(payload, "start")
+	if !ok {
+		return ""
+	}
+	count, ok := numericField(payload, "count")
+	if !ok || count <= 0 {
+		return ""
+	}
+	total, ok := numericField(payload, "total")
+	if !ok || total <= 0 {
+		return ""
+	}
+	next := start + count
+	if next >= total {
+		return ""
+	}
+	return strconv.Itoa(next)
+}
+
+func numericField(payload map[string]any, key string) (int, bool) {
+	value, ok := payload[key]
+	if !ok {
+		return 0, false
+	}
+	switch typed := value.(type) {
+	case float64:
+		return int(typed), true
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(parsed), true
+	default:
+		return 0, false
+	}
+}
+
+func annotateRequestError(err error, req *http.Request) error {
+	apiErr, ok := err.(*Error)
+	if !ok || req == nil {
+		return err
+	}
+	if apiErr.Diagnostics == nil {
+		apiErr.Diagnostics = map[string]any{}
+	}
+	apiErr.Diagnostics["request"] = map[string]any{
+		"method":    req.Method,
+		"path":      req.URL.Path,
+		"raw_query": req.URL.RawQuery,
+	}
+	return apiErr
 }
 
 func decodeCollectionElements(body any) ([]map[string]any, error) {

--- a/internal/linkedin/client_test.go
+++ b/internal/linkedin/client_test.go
@@ -165,3 +165,44 @@ func TestFetchCollectionFollowsNextURL(t *testing.T) {
 		t.Fatalf("unexpected paging: %#v", paging)
 	}
 }
+
+func TestFetchCollectionUsesCustomOffsetPagingParams(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"id":"1"}],"paging":{"count":25,"start":50,"total":100}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+
+	seen := make([]string, 0, 1)
+	paging, err := client.FetchCollection(context.Background(), Request{
+		Method: http.MethodGet,
+		Path:   "/rest/adAnalytics",
+		Query:  map[string]string{"q": "analytics"},
+	}, PaginationOptions{
+		PageSizeParam:  "count",
+		PageTokenParam: "start",
+		PageSize:       25,
+		PageToken:      "50",
+	}, func(row map[string]any) error {
+		seen = append(seen, row["id"].(string))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("fetch collection: %v", err)
+	}
+	if len(seen) != 1 || seen[0] != "1" {
+		t.Fatalf("unexpected rows: %#v", seen)
+	}
+	req := httpClient.requests[0]
+	if got := req.URL.Query().Get("count"); got != "25" {
+		t.Fatalf("unexpected count query %q", got)
+	}
+	if got := req.URL.Query().Get("start"); got != "50" {
+		t.Fatalf("unexpected start query %q", got)
+	}
+	if paging == nil || paging.NextPageToken != "75" {
+		t.Fatalf("unexpected paging: %#v", paging)
+	}
+}

--- a/internal/linkedin/client_test.go
+++ b/internal/linkedin/client_test.go
@@ -108,6 +108,34 @@ func TestDoUsesQueryTunnelingForLongQueries(t *testing.T) {
 	}
 }
 
+func TestDoPreservesFieldCommasInRawQuery(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t:         t,
+		responses: []*http.Response{responseJSON(http.StatusOK, `{"ok":true}`)},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+
+	_, err := client.Do(context.Background(), Request{
+		Method: http.MethodGet,
+		Path:   "/rest/adAnalytics",
+		Query: map[string]string{
+			"q":      "analytics",
+			"fields": "dateRange,pivotValues,impressions,clicks",
+		},
+	})
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+
+	req := httpClient.requests[0]
+	if got := req.URL.RawQuery; !strings.Contains(got, "fields=dateRange,pivotValues,impressions,clicks") {
+		t.Fatalf("unexpected raw query %q", got)
+	}
+	if got := req.URL.RawQuery; strings.Contains(got, "fields=dateRange%2CpivotValues%2Cimpressions%2Cclicks") {
+		t.Fatalf("unexpected escaped fields query %q", got)
+	}
+}
+
 func TestFetchCollectionFollowsNextURL(t *testing.T) {
 	httpClient := &recordingHTTPClient{
 		t: t,

--- a/internal/linkedin/client_test.go
+++ b/internal/linkedin/client_test.go
@@ -1,0 +1,139 @@
+package linkedin
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type recordingHTTPClient struct {
+	t *testing.T
+
+	responses []*http.Response
+	requests  []*http.Request
+}
+
+func (c *recordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.requests = append(c.requests, req)
+	if len(c.responses) == 0 {
+		c.t.Fatal("unexpected request with no stubbed response")
+	}
+	res := c.responses[0]
+	c.responses = c.responses[1:]
+	return res, nil
+}
+
+func responseJSON(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestDoInjectsLinkedInHeaders(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t:         t,
+		responses: []*http.Response{responseJSON(http.StatusOK, `{"ok":true}`)},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+
+	resp, err := client.Do(context.Background(), Request{
+		Method: http.MethodGet,
+		Path:   "/rest/adAccounts",
+		Query:  map[string]string{"q": "search"},
+	})
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+
+	if len(httpClient.requests) != 1 {
+		t.Fatalf("unexpected request count %d", len(httpClient.requests))
+	}
+	req := httpClient.requests[0]
+	if got := req.Header.Get("Authorization"); got != "Bearer token-123" {
+		t.Fatalf("unexpected auth header %q", got)
+	}
+	if got := req.Header.Get("Linkedin-Version"); got != "202402" {
+		t.Fatalf("unexpected version header %q", got)
+	}
+	if got := req.Header.Get("X-Restli-Protocol-Version"); got != DefaultRestliProtocol {
+		t.Fatalf("unexpected restli header %q", got)
+	}
+	if got := req.URL.Path; got != "/rest/adAccounts" {
+		t.Fatalf("unexpected path %q", got)
+	}
+	if got := req.URL.Query().Get("q"); got != "search" {
+		t.Fatalf("unexpected query %q", got)
+	}
+}
+
+func TestDoUsesQueryTunnelingForLongQueries(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t:         t,
+		responses: []*http.Response{responseJSON(http.StatusOK, `{"ok":true}`)},
+	}
+	client := NewClient(httpClient, "", "202402", "token-123")
+	client.QueryTunnelThreshold = 10
+
+	_, err := client.Do(context.Background(), Request{
+		Method: http.MethodGet,
+		Path:   "/rest/adAccounts",
+		Query: map[string]string{
+			"q":      "search",
+			"filter": "this-is-long",
+		},
+		AllowQueryTunneling: true,
+	})
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	if len(httpClient.requests) != 1 {
+		t.Fatalf("unexpected request count %d", len(httpClient.requests))
+	}
+	req := httpClient.requests[0]
+	if req.Method != http.MethodPost {
+		t.Fatalf("unexpected method %s", req.Method)
+	}
+	if got := req.Header.Get("X-HTTP-Method-Override"); got != http.MethodGet {
+		t.Fatalf("unexpected override header %q", got)
+	}
+	if body, _ := io.ReadAll(req.Body); len(body) == 0 {
+		t.Fatal("expected tunneled query in request body")
+	}
+}
+
+func TestFetchCollectionFollowsNextURL(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"id":"1"}],"paging":{"links":[{"rel":"next","href":"/rest/adAccounts?pageToken=abc"}]}}`),
+			responseJSON(http.StatusOK, `{"elements":[{"id":"2"}],"paging":{"count":2}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+
+	seen := make([]string, 0, 2)
+	paging, err := client.FetchCollection(context.Background(), Request{
+		Method: http.MethodGet,
+		Path:   "/rest/adAccounts",
+		Query:  map[string]string{"q": "search"},
+	}, PaginationOptions{FollowNext: true}, func(row map[string]any) error {
+		seen = append(seen, row["id"].(string))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("fetch collection: %v", err)
+	}
+	if len(seen) != 2 || seen[0] != "1" || seen[1] != "2" {
+		t.Fatalf("unexpected rows: %#v", seen)
+	}
+	if paging == nil || paging.NextPageToken != "" {
+		t.Fatalf("unexpected paging: %#v", paging)
+	}
+}

--- a/internal/linkedin/errors.go
+++ b/internal/linkedin/errors.go
@@ -1,0 +1,206 @@
+package linkedin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type ErrorCategory string
+
+const (
+	ErrorCategoryAuth       ErrorCategory = "auth"
+	ErrorCategoryPermission ErrorCategory = "permission"
+	ErrorCategoryValidation ErrorCategory = "validation"
+	ErrorCategoryRateLimit  ErrorCategory = "rate_limit"
+	ErrorCategoryVersion    ErrorCategory = "version"
+	ErrorCategoryTransient  ErrorCategory = "transient"
+	ErrorCategoryNotFound   ErrorCategory = "not_found"
+	ErrorCategoryConflict   ErrorCategory = "conflict"
+	ErrorCategoryUnknown    ErrorCategory = "unknown"
+)
+
+type Error struct {
+	Category         ErrorCategory  `json:"category"`
+	StatusCode       int            `json:"status_code"`
+	Code             string         `json:"code,omitempty"`
+	ServiceErrorCode int            `json:"service_error_code,omitempty"`
+	ErrorDetailType  string         `json:"error_detail_type,omitempty"`
+	Message          string         `json:"message"`
+	Retryable        bool           `json:"retryable"`
+	Raw              []byte         `json:"raw,omitempty"`
+	Diagnostics      map[string]any `json:"diagnostics,omitempty"`
+}
+
+type APIError = Error
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	parts := []string{fmt.Sprintf("linkedin api error category=%s status=%d", e.Category, e.StatusCode)}
+	if strings.TrimSpace(e.Code) != "" {
+		parts = append(parts, fmt.Sprintf("code=%s", e.Code))
+	}
+	if strings.TrimSpace(e.ErrorDetailType) != "" {
+		parts = append(parts, fmt.Sprintf("detail_type=%s", e.ErrorDetailType))
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		parts = append(parts, e.Message)
+	}
+	return strings.Join(parts, ": ")
+}
+
+func ValidateVersion(version string) error {
+	if strings.TrimSpace(version) == "" {
+		return fmt.Errorf("linkedin version is required")
+	}
+	return nil
+}
+
+func parseAPIError(statusCode int, decoded any, headers http.Header, raw []byte) error {
+	payload, _ := decoded.(map[string]any)
+	message := extractMessage(payload)
+	category := classifyLinkedInCategory(statusCode, payload, message)
+	return &Error{
+		Category:    category,
+		StatusCode:  statusCode,
+		Message:     message,
+		Retryable:   category == ErrorCategoryTransient || category == ErrorCategoryRateLimit,
+		Raw:         append([]byte(nil), raw...),
+		Diagnostics: cloneAnyMap(payload),
+	}
+}
+
+func classifyLinkedInError(statusCode int, body []byte) error {
+	var decoded any
+	if len(body) > 0 {
+		_ = json.Unmarshal(body, &decoded)
+	}
+	return parseAPIError(statusCode, decoded, nil, body)
+}
+
+func classifyLinkedInCategory(statusCode int, payload map[string]any, message string) ErrorCategory {
+	_ = payload
+	upper := strings.ToUpper(strings.TrimSpace(message))
+	switch {
+	case statusCode == http.StatusUnauthorized || strings.Contains(upper, "INVALID TOKEN") || strings.Contains(upper, "EXPIRED"):
+		return ErrorCategoryAuth
+	case statusCode == http.StatusForbidden || strings.Contains(upper, "PERMISSION") || strings.Contains(upper, "ACCESS DENIED"):
+		return ErrorCategoryPermission
+	case statusCode == http.StatusNotFound:
+		return ErrorCategoryNotFound
+	case statusCode == http.StatusConflict:
+		return ErrorCategoryConflict
+	case statusCode == http.StatusTooManyRequests || strings.Contains(upper, "RATE") || strings.Contains(upper, "THROTTLE"):
+		return ErrorCategoryRateLimit
+	case statusCode == http.StatusUpgradeRequired || strings.Contains(upper, "VERSION"):
+		return ErrorCategoryVersion
+	case statusCode >= 500:
+		return ErrorCategoryTransient
+	case statusCode == http.StatusBadRequest:
+		if strings.Contains(upper, "VERSION") {
+			return ErrorCategoryVersion
+		}
+		return ErrorCategoryValidation
+	default:
+		if strings.Contains(upper, "VERSION") {
+			return ErrorCategoryVersion
+		}
+		if strings.Contains(upper, "RATE") {
+			return ErrorCategoryRateLimit
+		}
+		if strings.Contains(upper, "PERMISSION") {
+			return ErrorCategoryPermission
+		}
+		if strings.Contains(upper, "NOT FOUND") {
+			return ErrorCategoryNotFound
+		}
+		return ErrorCategoryUnknown
+	}
+}
+
+func cloneAnyMap(source map[string]any) map[string]any {
+	if len(source) == 0 {
+		return nil
+	}
+	cloned := make(map[string]any, len(source))
+	for key, value := range source {
+		cloned[key] = cloneAnyValue(value)
+	}
+	return cloned
+}
+
+func cloneAnyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		cloned := make([]any, 0, len(typed))
+		for _, item := range typed {
+			cloned = append(cloned, cloneAnyValue(item))
+		}
+		return cloned
+	default:
+		return typed
+	}
+}
+
+func stringField(payload map[string]any, key string) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	value, ok := payload[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := value.(string); ok {
+		return s
+	}
+	return fmt.Sprint(value)
+}
+
+func mustMarshalLoose(v any) []byte {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+func extractMessage(payload map[string]any) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	if errObj, ok := payload["error"].(map[string]any); ok {
+		if message, ok := errObj["message"].(string); ok && strings.TrimSpace(message) != "" {
+			return strings.TrimSpace(message)
+		}
+		if desc, ok := errObj["error_description"].(string); ok && strings.TrimSpace(desc) != "" {
+			return strings.TrimSpace(desc)
+		}
+	}
+	if message, ok := payload["message"].(string); ok && strings.TrimSpace(message) != "" {
+		return strings.TrimSpace(message)
+	}
+	if desc, ok := payload["error_description"].(string); ok && strings.TrimSpace(desc) != "" {
+		return strings.TrimSpace(desc)
+	}
+	return ""
+}
+
+func cloneAny(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		cloned := make([]any, 0, len(typed))
+		for _, item := range typed {
+			cloned = append(cloned, cloneAny(item))
+		}
+		return cloned
+	default:
+		return typed
+	}
+}

--- a/internal/linkedin/reporting.go
+++ b/internal/linkedin/reporting.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -73,6 +74,7 @@ const (
 	GranularityMonthly TimeGranularity = "MONTHLY"
 
 	QueryAnalytics   QueryKind = "analytics"
+	QueryStatistics  QueryKind = "statistics"
 	QueryDemographic QueryKind = "demographic"
 )
 
@@ -121,47 +123,71 @@ type ReportingService struct {
 	Client *Client
 }
 
-var metricPackDefinitions = map[MetricPack][]Metric{
+type metricPackDefinition struct {
+	Metrics          []Metric
+	DefaultMetrics   []Metric
+	UseDefaultFields bool
+}
+
+var metricPackDefinitions = map[MetricPack]metricPackDefinition{
 	PackBasic: {
-		MetricDateRange,
-		MetricPivotValues,
-		MetricImpressions,
-		MetricClicks,
+		DefaultMetrics:   []Metric{MetricImpressions, MetricClicks},
+		UseDefaultFields: true,
 	},
 	PackDelivery: {
-		MetricDateRange,
-		MetricPivotValues,
-		MetricImpressions,
-		MetricClicks,
-		MetricLandingPageClicks,
-		MetricCostInLocalCurrency,
+		Metrics: []Metric{
+			MetricDateRange,
+			MetricPivotValues,
+			MetricImpressions,
+			MetricLandingPageClicks,
+			MetricLikes,
+			MetricShares,
+			MetricCostInLocalCurrency,
+		},
 	},
 	PackLeadGen: {
-		MetricDateRange,
-		MetricPivotValues,
-		MetricImpressions,
-		MetricLandingPageClicks,
-		MetricCostInLocalCurrency,
-		MetricExternalWebsiteConv,
+		Metrics: []Metric{
+			MetricDateRange,
+			MetricPivotValues,
+			MetricImpressions,
+			MetricLandingPageClicks,
+			MetricCostInLocalCurrency,
+			MetricExternalWebsiteConv,
+		},
 	},
 	PackVideo: {
-		MetricDateRange,
-		MetricPivotValues,
-		MetricImpressions,
-		MetricClicks,
-		MetricLikes,
-		MetricShares,
+		Metrics: []Metric{
+			MetricDateRange,
+			MetricPivotValues,
+			MetricImpressions,
+			MetricLandingPageClicks,
+			MetricLikes,
+			MetricShares,
+		},
 	},
 	PackB2B: {
-		MetricDateRange,
-		MetricPivotValues,
-		MetricImpressions,
-		MetricClicks,
-		MetricLandingPageClicks,
-		MetricLikes,
-		MetricShares,
-		MetricCostInLocalCurrency,
+		Metrics: []Metric{
+			MetricDateRange,
+			MetricPivotValues,
+			MetricImpressions,
+			MetricLandingPageClicks,
+			MetricLikes,
+			MetricShares,
+			MetricCostInLocalCurrency,
+			MetricExternalWebsiteConv,
+		},
 	},
+}
+
+var supportedProjectedMetrics = map[Metric]struct{}{
+	MetricExternalWebsiteConv: {},
+	MetricDateRange:           {},
+	MetricImpressions:         {},
+	MetricLandingPageClicks:   {},
+	MetricLikes:               {},
+	MetricShares:              {},
+	MetricCostInLocalCurrency: {},
+	MetricPivotValues:         {},
 }
 
 var demographicPivots = map[Pivot]struct{}{
@@ -191,13 +217,30 @@ func NormalizeMetricPack(raw string) (MetricPack, error) {
 }
 
 func MetricPackMetrics(pack MetricPack) ([]Metric, error) {
-	metrics, ok := metricPackDefinitions[pack]
+	def, ok := metricPackDefinitions[pack]
 	if !ok {
 		return nil, fmt.Errorf("unsupported metric pack %q", pack)
 	}
+	metrics := def.Metrics
 	out := make([]Metric, len(metrics))
 	copy(out, metrics)
 	return out, nil
+}
+
+func MetricPackDefaultMetrics(pack MetricPack) ([]Metric, error) {
+	def, ok := metricPackDefinitions[pack]
+	if !ok {
+		return nil, fmt.Errorf("unsupported metric pack %q", pack)
+	}
+	metrics := def.DefaultMetrics
+	out := make([]Metric, len(metrics))
+	copy(out, metrics)
+	return out, nil
+}
+
+func MetricPackUsesDefaultFields(pack MetricPack) bool {
+	def, ok := metricPackDefinitions[pack]
+	return ok && def.UseDefaultFields
 }
 
 func NormalizeMetrics(metrics []string) ([]Metric, error) {
@@ -282,9 +325,16 @@ func ValidateReportingInput(input ReportingInput) error {
 	}
 	if pack != "" {
 		packMetrics, _ := MetricPackMetrics(pack)
-		if len(metrics) == 0 {
+		switch {
+		case len(metrics) == 0 && MetricPackUsesDefaultFields(pack):
+			metrics = nil
+		case len(metrics) == 0:
 			metrics = packMetrics
-		} else {
+		case MetricPackUsesDefaultFields(pack):
+			if err := validateProjectedMetrics(metrics); err != nil {
+				return err
+			}
+		default:
 			allowed := metricSet(packMetrics)
 			for _, metric := range metrics {
 				if _, ok := allowed[metric]; !ok {
@@ -292,6 +342,9 @@ func ValidateReportingInput(input ReportingInput) error {
 				}
 			}
 		}
+	}
+	if err := validateProjectedMetrics(metrics); err != nil {
+		return err
 	}
 
 	pivots, err := NormalizePivots(pivotsToStrings(input.Pivots))
@@ -302,8 +355,8 @@ func ValidateReportingInput(input ReportingInput) error {
 		pivots = append([]Pivot{Pivot(strings.ToUpper(strings.TrimSpace(string(input.Pivot))))}, pivots...)
 	}
 	pivots = dedupePivots(pivots)
-	if len(pivots) > 1 && input.QueryKind != QueryDemographic {
-		return errors.New("only one pivot is supported for analytics queries")
+	if len(pivots) > 3 {
+		return errors.New("at most three pivots are supported")
 	}
 	if input.Level == LevelCreative {
 		for _, pivot := range pivots {
@@ -381,7 +434,7 @@ func (s *ReportingService) Run(ctx context.Context, input ReportingInput) (*Repo
 	}
 
 	query := map[string]string{}
-	query["q"] = string(defaultQueryKind(input.QueryKind))
+	query["q"] = string(wireQueryKind(pivots))
 	query["dateRange"] = input.DateRange.Encode()
 	if input.TimeGranularity != "" {
 		query["timeGranularity"] = strings.ToUpper(string(input.TimeGranularity))
@@ -391,17 +444,21 @@ func (s *ReportingService) Run(ctx context.Context, input ReportingInput) (*Repo
 		query["fields"] = strings.Join(metricsToStrings(metrics), ",")
 	}
 	if len(pivots) > 0 {
-		if input.QueryKind == QueryDemographic {
+		if usesStatisticsQuery(pivots) {
 			query["pivots"] = listValue(pivotStrings(pivots)...)
 		} else {
 			query["pivot"] = string(pivots[0])
 		}
 	}
 	if input.PageSize > 0 {
-		query[DefaultPageSizeParam] = fmt.Sprintf("%d", input.PageSize)
+		query[DefaultOffsetCountParam] = fmt.Sprintf("%d", input.PageSize)
 	}
-	if strings.TrimSpace(input.PageToken) != "" {
-		query[DefaultPageTokenParam] = strings.TrimSpace(input.PageToken)
+	startToken := ""
+	if normalizedStartToken, err := normalizeOffsetToken(input.PageToken); err != nil {
+		return nil, err
+	} else if normalizedStartToken != "" {
+		startToken = normalizedStartToken
+		query[DefaultOffsetStartParam] = startToken
 	}
 
 	result := &ReportingResult{Rows: make([]map[string]any, 0)}
@@ -411,10 +468,12 @@ func (s *ReportingService) Run(ctx context.Context, input ReportingInput) (*Repo
 		Version: s.Client.Version,
 		Query:   query,
 	}, PaginationOptions{
-		FollowNext: input.FollowNext,
-		Limit:      input.Limit,
-		PageSize:   input.PageSize,
-		PageToken:  strings.TrimSpace(input.PageToken),
+		FollowNext:     input.FollowNext,
+		Limit:          input.Limit,
+		PageSize:       input.PageSize,
+		PageToken:      startToken,
+		PageSizeParam:  DefaultOffsetCountParam,
+		PageTokenParam: DefaultOffsetStartParam,
 	}, func(row map[string]any) error {
 		result.Rows = append(result.Rows, row)
 		return nil
@@ -437,20 +496,30 @@ func normalizeReportingMetrics(input ReportingInput) ([]Metric, error) {
 		if err != nil {
 			return nil, err
 		}
+		if MetricPackUsesDefaultFields(pack) {
+			return nil, nil
+		}
 		def, err := MetricPackMetrics(pack)
 		if err != nil {
 			return nil, err
 		}
 		metrics = def
 	}
+	if err := validateProjectedMetrics(metrics); err != nil {
+		return nil, err
+	}
 	return metrics, nil
 }
 
-func defaultQueryKind(kind QueryKind) QueryKind {
-	if strings.TrimSpace(string(kind)) == "" {
-		return QueryAnalytics
+func wireQueryKind(pivots []Pivot) QueryKind {
+	if usesStatisticsQuery(pivots) {
+		return QueryStatistics
 	}
-	return kind
+	return QueryAnalytics
+}
+
+func usesStatisticsQuery(pivots []Pivot) bool {
+	return len(pivots) > 1
 }
 
 func metricsToStrings(metrics []Metric) []string {
@@ -530,6 +599,31 @@ func metricSet(metrics []Metric) map[Metric]struct{} {
 		out[metric] = struct{}{}
 	}
 	return out
+}
+
+func validateProjectedMetrics(metrics []Metric) error {
+	for _, metric := range metrics {
+		if _, ok := supportedProjectedMetrics[metric]; ok {
+			continue
+		}
+		if metric == MetricClicks {
+			return errors.New("metric \"clicks\" is only available in LinkedIn's default analytics response; omit --metrics or use --metric-pack basic")
+		}
+		return fmt.Errorf("metric %q is not supported by LinkedIn's fields projection", metric)
+	}
+	return nil
+}
+
+func normalizeOffsetToken(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return "", fmt.Errorf("page token must be a non-negative integer offset")
+	}
+	return strconv.Itoa(value), nil
 }
 
 func validDate(value DateValue) bool {

--- a/internal/linkedin/reporting.go
+++ b/internal/linkedin/reporting.go
@@ -19,6 +19,13 @@ type QueryKind string
 const (
 	MetricImpressions         Metric = "impressions"
 	MetricClicks              Metric = "clicks"
+	MetricDateRange           Metric = "dateRange"
+	MetricPivotValues         Metric = "pivotValues"
+	MetricLandingPageClicks   Metric = "landingPageClicks"
+	MetricLikes               Metric = "likes"
+	MetricShares              Metric = "shares"
+	MetricCostInLocalCurrency Metric = "costInLocalCurrency"
+	MetricExternalWebsiteConv Metric = "externalWebsiteConversions"
 	MetricSpend               Metric = "spend"
 	MetricCPC                 Metric = "cpc"
 	MetricCPM                 Metric = "cpm"
@@ -116,50 +123,44 @@ type ReportingService struct {
 
 var metricPackDefinitions = map[MetricPack][]Metric{
 	PackBasic: {
+		MetricDateRange,
+		MetricPivotValues,
 		MetricImpressions,
 		MetricClicks,
-		MetricSpend,
-		MetricCPC,
-		MetricCPM,
-		MetricCTR,
-		MetricReach,
-		MetricFrequency,
 	},
 	PackDelivery: {
+		MetricDateRange,
+		MetricPivotValues,
 		MetricImpressions,
 		MetricClicks,
-		MetricSpend,
-		MetricCPC,
-		MetricCPM,
-		MetricCTR,
-		MetricReach,
-		MetricFrequency,
+		MetricLandingPageClicks,
+		MetricCostInLocalCurrency,
 	},
 	PackLeadGen: {
+		MetricDateRange,
+		MetricPivotValues,
 		MetricImpressions,
-		MetricClicks,
-		MetricSpend,
-		MetricLeads,
-		MetricLeadFormOpens,
-		MetricCostPerLead,
+		MetricLandingPageClicks,
+		MetricCostInLocalCurrency,
+		MetricExternalWebsiteConv,
 	},
 	PackVideo: {
+		MetricDateRange,
+		MetricPivotValues,
 		MetricImpressions,
 		MetricClicks,
-		MetricSpend,
-		MetricVideoViews,
-		MetricVideoStarts,
-		MetricVideoCompletions,
-		MetricVideoCompletionRate,
+		MetricLikes,
+		MetricShares,
 	},
 	PackB2B: {
+		MetricDateRange,
+		MetricPivotValues,
 		MetricImpressions,
 		MetricClicks,
-		MetricSpend,
-		MetricCompanyClicks,
-		MetricMemberCompany,
-		MetricMemberSeniority,
-		MetricMemberJobFunction,
+		MetricLandingPageClicks,
+		MetricLikes,
+		MetricShares,
+		MetricCostInLocalCurrency,
 	},
 }
 

--- a/internal/linkedin/reporting.go
+++ b/internal/linkedin/reporting.go
@@ -1,0 +1,565 @@
+package linkedin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Metric string
+type MetricPack string
+type Pivot string
+type ReportingLevel string
+type TimeGranularity string
+type QueryKind string
+
+const (
+	MetricImpressions         Metric = "impressions"
+	MetricClicks              Metric = "clicks"
+	MetricSpend               Metric = "spend"
+	MetricCPC                 Metric = "cpc"
+	MetricCPM                 Metric = "cpm"
+	MetricCTR                 Metric = "ctr"
+	MetricReach               Metric = "reach"
+	MetricFrequency           Metric = "frequency"
+	MetricVideoViews          Metric = "videoViews"
+	MetricVideoStarts         Metric = "videoStarts"
+	MetricVideoCompletions    Metric = "videoCompletions"
+	MetricVideoCompletionRate Metric = "videoCompletionRate"
+	MetricLeads               Metric = "leads"
+	MetricLeadFormOpens       Metric = "leadFormOpens"
+	MetricCostPerLead         Metric = "costPerLead"
+	MetricCompanyClicks       Metric = "companyClicks"
+	MetricMemberCompany       Metric = "memberCompany"
+	MetricMemberSeniority     Metric = "memberSeniority"
+	MetricMemberJobFunction   Metric = "memberJobFunction"
+
+	PackBasic    MetricPack = "basic"
+	PackDelivery MetricPack = "delivery"
+	PackLeadGen  MetricPack = "leadgen"
+	PackVideo    MetricPack = "video"
+	PackB2B      MetricPack = "b2b"
+
+	PivotAccount           Pivot = "ACCOUNT"
+	PivotCampaignGroup     Pivot = "CAMPAIGN_GROUP"
+	PivotCampaign          Pivot = "CAMPAIGN"
+	PivotCreative          Pivot = "CREATIVE"
+	PivotDay               Pivot = "DAY"
+	PivotMonth             Pivot = "MONTH"
+	PivotMemberCountry     Pivot = "MEMBER_COUNTRY"
+	PivotMemberRegion      Pivot = "MEMBER_REGION"
+	PivotMemberSeniority   Pivot = "MEMBER_SENIORITY"
+	PivotMemberCompany     Pivot = "MEMBER_COMPANY"
+	PivotMemberIndustry    Pivot = "MEMBER_INDUSTRY"
+	PivotMemberJobFunction Pivot = "MEMBER_JOB_FUNCTION"
+
+	LevelAccount       ReportingLevel = "ACCOUNT"
+	LevelCampaignGroup ReportingLevel = "CAMPAIGN_GROUP"
+	LevelCampaign      ReportingLevel = "CAMPAIGN"
+	LevelCreative      ReportingLevel = "CREATIVE"
+
+	GranularityAll     TimeGranularity = "ALL"
+	GranularityDaily   TimeGranularity = "DAILY"
+	GranularityMonthly TimeGranularity = "MONTHLY"
+
+	QueryAnalytics   QueryKind = "analytics"
+	QueryDemographic QueryKind = "demographic"
+)
+
+type DateValue struct {
+	Year  int `json:"year"`
+	Month int `json:"month"`
+	Day   int `json:"day"`
+}
+
+type DateRange struct {
+	Start DateValue `json:"start"`
+	End   DateValue `json:"end"`
+}
+
+type ReportingInput struct {
+	QueryKind       QueryKind       `json:"query_kind,omitempty"`
+	AccountURNs     []URN           `json:"account_urns"`
+	Level           ReportingLevel  `json:"level"`
+	MetricPack      MetricPack      `json:"metric_pack,omitempty"`
+	Metrics         []Metric        `json:"metrics,omitempty"`
+	Pivot           Pivot           `json:"pivot,omitempty"`
+	Pivots          []Pivot         `json:"pivots,omitempty"`
+	DateRange       *DateRange      `json:"date_range,omitempty"`
+	TimeGranularity TimeGranularity `json:"time_granularity,omitempty"`
+	PageSize        int             `json:"page_size,omitempty"`
+	PageToken       string          `json:"page_token,omitempty"`
+	Limit           int             `json:"limit,omitempty"`
+	FollowNext      bool            `json:"follow_next,omitempty"`
+}
+
+type ReportingWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Limit   int    `json:"limit,omitempty"`
+	Rows    int    `json:"rows,omitempty"`
+	More    bool   `json:"more,omitempty"`
+}
+
+type ReportingResult struct {
+	Rows     []map[string]any   `json:"rows"`
+	Paging   *PagingInfo        `json:"paging,omitempty"`
+	Warnings []ReportingWarning `json:"warnings,omitempty"`
+}
+
+type ReportingService struct {
+	Client *Client
+}
+
+var metricPackDefinitions = map[MetricPack][]Metric{
+	PackBasic: {
+		MetricImpressions,
+		MetricClicks,
+		MetricSpend,
+		MetricCPC,
+		MetricCPM,
+		MetricCTR,
+		MetricReach,
+		MetricFrequency,
+	},
+	PackDelivery: {
+		MetricImpressions,
+		MetricClicks,
+		MetricSpend,
+		MetricCPC,
+		MetricCPM,
+		MetricCTR,
+		MetricReach,
+		MetricFrequency,
+	},
+	PackLeadGen: {
+		MetricImpressions,
+		MetricClicks,
+		MetricSpend,
+		MetricLeads,
+		MetricLeadFormOpens,
+		MetricCostPerLead,
+	},
+	PackVideo: {
+		MetricImpressions,
+		MetricClicks,
+		MetricSpend,
+		MetricVideoViews,
+		MetricVideoStarts,
+		MetricVideoCompletions,
+		MetricVideoCompletionRate,
+	},
+	PackB2B: {
+		MetricImpressions,
+		MetricClicks,
+		MetricSpend,
+		MetricCompanyClicks,
+		MetricMemberCompany,
+		MetricMemberSeniority,
+		MetricMemberJobFunction,
+	},
+}
+
+var demographicPivots = map[Pivot]struct{}{
+	PivotMemberCountry:     {},
+	PivotMemberRegion:      {},
+	PivotMemberSeniority:   {},
+	PivotMemberCompany:     {},
+	PivotMemberIndustry:    {},
+	PivotMemberJobFunction: {},
+}
+
+var creativeUnsafeLeadGenMetrics = map[Metric]struct{}{
+	MetricLeads:         {},
+	MetricLeadFormOpens: {},
+	MetricCostPerLead:   {},
+}
+
+func NormalizeMetricPack(raw string) (MetricPack, error) {
+	pack := MetricPack(strings.ToLower(strings.TrimSpace(raw)))
+	if pack == "" {
+		return "", errors.New("metric pack is required")
+	}
+	if _, ok := metricPackDefinitions[pack]; !ok {
+		return "", fmt.Errorf("unsupported metric pack %q", raw)
+	}
+	return pack, nil
+}
+
+func MetricPackMetrics(pack MetricPack) ([]Metric, error) {
+	metrics, ok := metricPackDefinitions[pack]
+	if !ok {
+		return nil, fmt.Errorf("unsupported metric pack %q", pack)
+	}
+	out := make([]Metric, len(metrics))
+	copy(out, metrics)
+	return out, nil
+}
+
+func NormalizeMetrics(metrics []string) ([]Metric, error) {
+	out := make([]Metric, 0, len(metrics))
+	seen := map[Metric]struct{}{}
+	for _, raw := range metrics {
+		metric := Metric(strings.TrimSpace(raw))
+		if metric == "" {
+			return nil, errors.New("metrics contains blank entries")
+		}
+		if _, ok := seen[metric]; ok {
+			continue
+		}
+		seen[metric] = struct{}{}
+		out = append(out, metric)
+	}
+	return out, nil
+}
+
+func NormalizePivots(values []string) ([]Pivot, error) {
+	out := make([]Pivot, 0, len(values))
+	seen := map[Pivot]struct{}{}
+	for _, raw := range values {
+		pivot := Pivot(strings.ToUpper(strings.TrimSpace(raw)))
+		if pivot == "" {
+			return nil, errors.New("pivots contains blank entries")
+		}
+		if _, ok := seen[pivot]; ok {
+			continue
+		}
+		seen[pivot] = struct{}{}
+		out = append(out, pivot)
+	}
+	return out, nil
+}
+
+func ValidateDateRange(r DateRange) error {
+	if !validDate(r.Start) {
+		return errors.New("start date is invalid")
+	}
+	if !validDate(r.End) {
+		return errors.New("end date is invalid")
+	}
+	start := time.Date(r.Start.Year, time.Month(r.Start.Month), r.Start.Day, 0, 0, 0, 0, time.UTC)
+	end := time.Date(r.End.Year, time.Month(r.End.Month), r.End.Day, 0, 0, 0, 0, time.UTC)
+	if end.Before(start) {
+		return errors.New("date range end must not be before start")
+	}
+	return nil
+}
+
+func (r DateRange) Encode() string {
+	return fmt.Sprintf("(start:(year:%d,month:%d,day:%d),end:(year:%d,month:%d,day:%d))", r.Start.Year, r.Start.Month, r.Start.Day, r.End.Year, r.End.Month, r.End.Day)
+}
+
+func ValidateReportingInput(input ReportingInput) error {
+	if len(input.AccountURNs) == 0 {
+		return errors.New("at least one account urn is required")
+	}
+	if err := ValidateReportingLevel(input.Level); err != nil {
+		return err
+	}
+	if input.DateRange == nil {
+		return errors.New("date range is required")
+	}
+	if err := ValidateDateRange(*input.DateRange); err != nil {
+		return err
+	}
+
+	pack := input.MetricPack
+	if pack != "" {
+		normalized, err := NormalizeMetricPack(string(pack))
+		if err != nil {
+			return err
+		}
+		pack = normalized
+	}
+
+	metrics, err := NormalizeMetrics(metricsToStrings(input.Metrics))
+	if err != nil {
+		return err
+	}
+	if pack != "" {
+		packMetrics, _ := MetricPackMetrics(pack)
+		if len(metrics) == 0 {
+			metrics = packMetrics
+		} else {
+			allowed := metricSet(packMetrics)
+			for _, metric := range metrics {
+				if _, ok := allowed[metric]; !ok {
+					return fmt.Errorf("metric %q is not allowed in pack %q", metric, pack)
+				}
+			}
+		}
+	}
+
+	pivots, err := NormalizePivots(pivotsToStrings(input.Pivots))
+	if err != nil {
+		return err
+	}
+	if input.Pivot != "" {
+		pivots = append([]Pivot{Pivot(strings.ToUpper(strings.TrimSpace(string(input.Pivot))))}, pivots...)
+	}
+	pivots = dedupePivots(pivots)
+	if len(pivots) > 1 && input.QueryKind != QueryDemographic {
+		return errors.New("only one pivot is supported for analytics queries")
+	}
+	if input.Level == LevelCreative {
+		for _, pivot := range pivots {
+			if _, ok := demographicPivots[pivot]; ok {
+				return fmt.Errorf("pivot %q is not supported at creative level", pivot)
+			}
+		}
+	}
+	for _, metric := range metrics {
+		if _, ok := creativeUnsafeLeadGenMetrics[metric]; ok {
+			for _, pivot := range pivots {
+				if pivot == PivotCreative {
+					return fmt.Errorf("metric %q cannot be used with pivot %q", metric, pivot)
+				}
+			}
+		}
+	}
+
+	if input.QueryKind == QueryDemographic {
+		if len(demographicWarnings(pivots)) == 0 {
+			return errors.New("demographic queries require at least one demographic pivot")
+		}
+	}
+	return nil
+}
+
+func ValidateReportingLevel(level ReportingLevel) error {
+	switch level {
+	case LevelAccount, LevelCampaignGroup, LevelCampaign, LevelCreative:
+		return nil
+	default:
+		return fmt.Errorf("unsupported reporting level %q", level)
+	}
+}
+
+func DemographicCaveats(input ReportingInput) []ReportingWarning {
+	warnings := demographicWarnings(dedupedPivotsFromInput(input))
+	if len(warnings) == 0 {
+		return nil
+	}
+	out := make([]ReportingWarning, 0, len(warnings)+1)
+	out = append(out, warnings...)
+	out = append(out, ReportingWarning{
+		Code:    "demographic_threshold",
+		Message: "LinkedIn demographic reporting is subject to privacy thresholds and may omit sparse slices.",
+	})
+	return out
+}
+
+func TruncationWarning(limit int, rows int, nextPageURL string) *ReportingWarning {
+	if limit <= 0 || rows < limit || strings.TrimSpace(nextPageURL) == "" {
+		return nil
+	}
+	return &ReportingWarning{
+		Code:    "truncation",
+		Message: "reporting output may be truncated because additional pages are available and follow-next is disabled.",
+		Limit:   limit,
+		Rows:    rows,
+		More:    true,
+	}
+}
+
+func (s *ReportingService) Run(ctx context.Context, input ReportingInput) (*ReportingResult, error) {
+	if s == nil || s.Client == nil {
+		return nil, errors.New("reporting client is required")
+	}
+	if err := ValidateReportingInput(input); err != nil {
+		return nil, err
+	}
+
+	metrics, _ := normalizeReportingMetrics(input)
+	pivots := dedupedPivotsFromInput(input)
+	if len(pivots) == 0 && input.QueryKind != QueryDemographic {
+		pivots = []Pivot{Pivot(strings.ToUpper(string(input.Level)))}
+	}
+
+	query := map[string]string{}
+	query["q"] = string(defaultQueryKind(input.QueryKind))
+	query["dateRange"] = input.DateRange.Encode()
+	if input.TimeGranularity != "" {
+		query["timeGranularity"] = strings.ToUpper(string(input.TimeGranularity))
+	}
+	query["accounts"] = listValue(urnStrings(input.AccountURNs)...)
+	if len(metrics) > 0 {
+		query["fields"] = strings.Join(metricsToStrings(metrics), ",")
+	}
+	if len(pivots) > 0 {
+		if input.QueryKind == QueryDemographic {
+			query["pivots"] = listValue(pivotStrings(pivots)...)
+		} else {
+			query["pivot"] = string(pivots[0])
+		}
+	}
+	if input.PageSize > 0 {
+		query[DefaultPageSizeParam] = fmt.Sprintf("%d", input.PageSize)
+	}
+	if strings.TrimSpace(input.PageToken) != "" {
+		query[DefaultPageTokenParam] = strings.TrimSpace(input.PageToken)
+	}
+
+	result := &ReportingResult{Rows: make([]map[string]any, 0)}
+	paging, err := s.Client.FetchCollection(ctx, Request{
+		Method:  http.MethodGet,
+		Path:    "/rest/adAnalytics",
+		Version: s.Client.Version,
+		Query:   query,
+	}, PaginationOptions{
+		FollowNext: input.FollowNext,
+		Limit:      input.Limit,
+		PageSize:   input.PageSize,
+		PageToken:  strings.TrimSpace(input.PageToken),
+	}, func(row map[string]any) error {
+		result.Rows = append(result.Rows, row)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Paging = paging
+	if warning := TruncationWarning(input.Limit, len(result.Rows), nextPageToken(paging)); warning != nil {
+		result.Warnings = append(result.Warnings, *warning)
+	}
+	result.Warnings = append(result.Warnings, DemographicCaveats(input)...)
+	return result, nil
+}
+
+func normalizeReportingMetrics(input ReportingInput) ([]Metric, error) {
+	metrics := append([]Metric(nil), input.Metrics...)
+	if len(metrics) == 0 && input.MetricPack != "" {
+		pack, err := NormalizeMetricPack(string(input.MetricPack))
+		if err != nil {
+			return nil, err
+		}
+		def, err := MetricPackMetrics(pack)
+		if err != nil {
+			return nil, err
+		}
+		metrics = def
+	}
+	return metrics, nil
+}
+
+func defaultQueryKind(kind QueryKind) QueryKind {
+	if strings.TrimSpace(string(kind)) == "" {
+		return QueryAnalytics
+	}
+	return kind
+}
+
+func metricsToStrings(metrics []Metric) []string {
+	out := make([]string, 0, len(metrics))
+	for _, metric := range metrics {
+		out = append(out, string(metric))
+	}
+	return out
+}
+
+func pivotsToStrings(pivots []Pivot) []string {
+	out := make([]string, 0, len(pivots))
+	for _, pivot := range pivots {
+		out = append(out, string(pivot))
+	}
+	return out
+}
+
+func pivotStrings(pivots []Pivot) []string {
+	return pivotsToStrings(pivots)
+}
+
+func urnStrings(urns []URN) []string {
+	out := make([]string, 0, len(urns))
+	for _, urn := range urns {
+		out = append(out, urn.String())
+	}
+	return out
+}
+
+func listValue(values ...string) string {
+	values = compactStrings(values)
+	return "List(" + strings.Join(values, ",") + ")"
+}
+
+func compactStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func dedupePivots(values []Pivot) []Pivot {
+	out := make([]Pivot, 0, len(values))
+	seen := map[Pivot]struct{}{}
+	for _, pivot := range values {
+		pivot = Pivot(strings.ToUpper(strings.TrimSpace(string(pivot))))
+		if pivot == "" {
+			continue
+		}
+		if _, ok := seen[pivot]; ok {
+			continue
+		}
+		seen[pivot] = struct{}{}
+		out = append(out, pivot)
+	}
+	return out
+}
+
+func dedupedPivotsFromInput(input ReportingInput) []Pivot {
+	pivots := make([]Pivot, 0, len(input.Pivots)+1)
+	if input.Pivot != "" {
+		pivots = append(pivots, Pivot(strings.ToUpper(strings.TrimSpace(string(input.Pivot)))))
+	}
+	pivots = append(pivots, input.Pivots...)
+	return dedupePivots(pivots)
+}
+
+func metricSet(metrics []Metric) map[Metric]struct{} {
+	out := make(map[Metric]struct{}, len(metrics))
+	for _, metric := range metrics {
+		out[metric] = struct{}{}
+	}
+	return out
+}
+
+func validDate(value DateValue) bool {
+	if value.Year <= 0 || value.Month <= 0 || value.Month > 12 || value.Day <= 0 || value.Day > 31 {
+		return false
+	}
+	t := time.Date(value.Year, time.Month(value.Month), value.Day, 0, 0, 0, 0, time.UTC)
+	return t.Year() == value.Year && int(t.Month()) == value.Month && t.Day() == value.Day
+}
+
+func demographicWarnings(pivots []Pivot) []ReportingWarning {
+	for _, pivot := range pivots {
+		if _, ok := demographicPivots[pivot]; ok {
+			return []ReportingWarning{
+				{
+					Code:    "demographic_threshold",
+					Message: "LinkedIn demographic reporting can suppress sparse groups to protect member privacy.",
+				},
+				{
+					Code:    "demographic_latency",
+					Message: "Demographic reporting may lag behind delivery reporting by several hours.",
+				},
+			}
+		}
+	}
+	return nil
+}
+
+func nextPageToken(paging *PagingInfo) string {
+	if paging == nil {
+		return ""
+	}
+	return strings.TrimSpace(paging.NextPageToken)
+}

--- a/internal/linkedin/reporting_test.go
+++ b/internal/linkedin/reporting_test.go
@@ -1,0 +1,137 @@
+package linkedin
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestValidateReportingInputRejectsInvalidPackMetricCombo(t *testing.T) {
+	dr := DateRange{
+		Start: DateValue{Year: 2026, Month: 1, Day: 1},
+		End:   DateValue{Year: 2026, Month: 1, Day: 31},
+	}
+	err := ValidateReportingInput(ReportingInput{
+		AccountURNs: []URN{"urn:li:sponsoredAccount:123"},
+		Level:       LevelCampaign,
+		MetricPack:  PackLeadGen,
+		Metrics:     []Metric{MetricLeads, MetricVideoViews},
+		DateRange:   &dr,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not allowed in pack") {
+		t.Fatalf("expected pack validation failure, got %v", err)
+	}
+}
+
+func TestValidateReportingInputRejectsInvalidPivotCombination(t *testing.T) {
+	dr := DateRange{
+		Start: DateValue{Year: 2026, Month: 1, Day: 1},
+		End:   DateValue{Year: 2026, Month: 1, Day: 31},
+	}
+	err := ValidateReportingInput(ReportingInput{
+		AccountURNs: []URN{"urn:li:sponsoredAccount:123"},
+		Level:       LevelCreative,
+		Metrics:     []Metric{MetricClicks},
+		Pivot:       PivotMemberCompany,
+		DateRange:   &dr,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not supported at creative level") {
+		t.Fatalf("expected pivot validation failure, got %v", err)
+	}
+}
+
+func TestValidateDateRange(t *testing.T) {
+	err := ValidateDateRange(DateRange{
+		Start: DateValue{Year: 2026, Month: 3, Day: 10},
+		End:   DateValue{Year: 2026, Month: 3, Day: 9},
+	})
+	if err == nil {
+		t.Fatal("expected invalid date range")
+	}
+}
+
+func TestReportingServiceBuildsAnalyticsQuery(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"pivotValues":["urn:li:sponsoredAccount:123"],"impressions":10}],"paging":{"count":1}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := &ReportingService{Client: client}
+
+	dr := DateRange{
+		Start: DateValue{Year: 2026, Month: 3, Day: 1},
+		End:   DateValue{Year: 2026, Month: 3, Day: 31},
+	}
+	result, err := service.Run(context.Background(), ReportingInput{
+		AccountURNs:     []URN{"urn:li:sponsoredAccount:123"},
+		Level:           LevelCampaign,
+		MetricPack:      PackBasic,
+		Pivot:           PivotCampaign,
+		DateRange:       &dr,
+		TimeGranularity: GranularityDaily,
+		PageSize:        50,
+	})
+	if err != nil {
+		t.Fatalf("run reporting: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("unexpected row count %d", len(result.Rows))
+	}
+
+	req := httpClient.requests[0]
+	if got := req.URL.Path; got != "/rest/adAnalytics" {
+		t.Fatalf("unexpected path %q", got)
+	}
+	query := req.URL.Query()
+	if got := query.Get("q"); got != string(QueryAnalytics) {
+		t.Fatalf("unexpected q %q", got)
+	}
+	if got := query.Get("accounts"); got != "List(urn:li:sponsoredAccount:123)" {
+		t.Fatalf("unexpected accounts query %q", got)
+	}
+	if got := query.Get("pivot"); got != string(PivotCampaign) {
+		t.Fatalf("unexpected pivot query %q", got)
+	}
+	if got := query.Get("fields"); !strings.Contains(got, "impressions") {
+		t.Fatalf("unexpected fields query %q", got)
+	}
+	if got := query.Get("dateRange"); !strings.Contains(got, "start:(year:2026,month:3,day:1)") {
+		t.Fatalf("unexpected dateRange query %q", got)
+	}
+	if got := query.Get("pageSize"); got != "50" {
+		t.Fatalf("unexpected pageSize %q", got)
+	}
+}
+
+func TestDemographicCaveatsReturnWarnings(t *testing.T) {
+	warnings := DemographicCaveats(ReportingInput{
+		Pivots: []Pivot{PivotMemberIndustry},
+	})
+	if len(warnings) == 0 {
+		t.Fatal("expected demographic caveats")
+	}
+}
+
+func TestTruncationWarning(t *testing.T) {
+	warning := TruncationWarning(10, 10, "/rest/adAnalytics?pageToken=abc")
+	if warning == nil || warning.Code != "truncation" {
+		t.Fatalf("unexpected warning %#v", warning)
+	}
+}
+
+func TestNormalizeMetricPackAndMetrics(t *testing.T) {
+	pack, err := NormalizeMetricPack("basic")
+	if err != nil {
+		t.Fatalf("normalize pack: %v", err)
+	}
+	metrics, err := MetricPackMetrics(pack)
+	if err != nil {
+		t.Fatalf("pack metrics: %v", err)
+	}
+	if len(metrics) == 0 {
+		t.Fatal("expected pack metrics")
+	}
+}

--- a/internal/linkedin/reporting_test.go
+++ b/internal/linkedin/reporting_test.go
@@ -95,8 +95,14 @@ func TestReportingServiceBuildsAnalyticsQuery(t *testing.T) {
 	if got := query.Get("pivot"); got != string(PivotCampaign) {
 		t.Fatalf("unexpected pivot query %q", got)
 	}
-	if got := query.Get("fields"); !strings.Contains(got, "impressions") {
+	if got := query.Get("fields"); got != "dateRange,pivotValues,impressions,clicks" {
 		t.Fatalf("unexpected fields query %q", got)
+	}
+	if got := req.URL.RawQuery; !strings.Contains(got, "fields=dateRange,pivotValues,impressions,clicks") {
+		t.Fatalf("unexpected raw query %q", got)
+	}
+	if got := req.URL.RawQuery; strings.Contains(got, "fields=dateRange%2CpivotValues%2Cimpressions%2Cclicks") {
+		t.Fatalf("fields projection should not escape commas: %q", got)
 	}
 	if got := query.Get("dateRange"); !strings.Contains(got, "start:(year:2026,month:3,day:1)") {
 		t.Fatalf("unexpected dateRange query %q", got)

--- a/internal/linkedin/reporting_test.go
+++ b/internal/linkedin/reporting_test.go
@@ -32,7 +32,7 @@ func TestValidateReportingInputRejectsInvalidPivotCombination(t *testing.T) {
 	err := ValidateReportingInput(ReportingInput{
 		AccountURNs: []URN{"urn:li:sponsoredAccount:123"},
 		Level:       LevelCreative,
-		Metrics:     []Metric{MetricClicks},
+		Metrics:     []Metric{MetricImpressions},
 		Pivot:       PivotMemberCompany,
 		DateRange:   &dr,
 	})
@@ -55,7 +55,7 @@ func TestReportingServiceBuildsAnalyticsQuery(t *testing.T) {
 	httpClient := &recordingHTTPClient{
 		t: t,
 		responses: []*http.Response{
-			responseJSON(http.StatusOK, `{"elements":[{"pivotValues":["urn:li:sponsoredAccount:123"],"impressions":10}],"paging":{"count":1}}`),
+			responseJSON(http.StatusOK, `{"elements":[{"pivotValues":["urn:li:sponsoredAccount:123"],"dateRange":{"start":{"year":2026,"month":3,"day":1},"end":{"year":2026,"month":3,"day":1}},"impressions":10,"clicks":2}],"paging":{"count":50,"start":50,"total":120}}`),
 		},
 	}
 	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
@@ -67,18 +67,22 @@ func TestReportingServiceBuildsAnalyticsQuery(t *testing.T) {
 	}
 	result, err := service.Run(context.Background(), ReportingInput{
 		AccountURNs:     []URN{"urn:li:sponsoredAccount:123"},
-		Level:           LevelCampaign,
+		Level:           LevelAccount,
 		MetricPack:      PackBasic,
-		Pivot:           PivotCampaign,
+		Pivot:           PivotAccount,
 		DateRange:       &dr,
 		TimeGranularity: GranularityDaily,
 		PageSize:        50,
+		PageToken:       "50",
 	})
 	if err != nil {
 		t.Fatalf("run reporting: %v", err)
 	}
 	if len(result.Rows) != 1 {
 		t.Fatalf("unexpected row count %d", len(result.Rows))
+	}
+	if result.Paging == nil || result.Paging.NextPageToken != "100" {
+		t.Fatalf("unexpected paging %#v", result.Paging)
 	}
 
 	req := httpClient.requests[0]
@@ -92,23 +96,76 @@ func TestReportingServiceBuildsAnalyticsQuery(t *testing.T) {
 	if got := query.Get("accounts"); got != "List(urn:li:sponsoredAccount:123)" {
 		t.Fatalf("unexpected accounts query %q", got)
 	}
-	if got := query.Get("pivot"); got != string(PivotCampaign) {
+	if got := query.Get("pivot"); got != string(PivotAccount) {
 		t.Fatalf("unexpected pivot query %q", got)
 	}
-	if got := query.Get("fields"); got != "dateRange,pivotValues,impressions,clicks" {
-		t.Fatalf("unexpected fields query %q", got)
-	}
-	if got := req.URL.RawQuery; !strings.Contains(got, "fields=dateRange,pivotValues,impressions,clicks") {
-		t.Fatalf("unexpected raw query %q", got)
-	}
-	if got := req.URL.RawQuery; strings.Contains(got, "fields=dateRange%2CpivotValues%2Cimpressions%2Cclicks") {
-		t.Fatalf("fields projection should not escape commas: %q", got)
+	if got := query.Get("fields"); got != "" {
+		t.Fatalf("expected basic pack to omit fields, got %q", got)
 	}
 	if got := query.Get("dateRange"); !strings.Contains(got, "start:(year:2026,month:3,day:1)") {
 		t.Fatalf("unexpected dateRange query %q", got)
 	}
-	if got := query.Get("pageSize"); got != "50" {
-		t.Fatalf("unexpected pageSize %q", got)
+	if got := query.Get("count"); got != "50" {
+		t.Fatalf("unexpected count %q", got)
+	}
+	if got := query.Get("start"); got != "50" {
+		t.Fatalf("unexpected start %q", got)
+	}
+}
+
+func TestReportingServiceUsesStatisticsForMultiPivotRuns(t *testing.T) {
+	httpClient := &recordingHTTPClient{
+		t: t,
+		responses: []*http.Response{
+			responseJSON(http.StatusOK, `{"elements":[{"pivotValues":["urn:li:organization:1"],"impressions":10}],"paging":{"count":1}}`),
+		},
+	}
+	client := NewClient(httpClient, "https://api.linkedin.com", "202402", "token-123")
+	service := &ReportingService{Client: client}
+
+	dr := DateRange{
+		Start: DateValue{Year: 2026, Month: 3, Day: 1},
+		End:   DateValue{Year: 2026, Month: 3, Day: 31},
+	}
+	_, err := service.Run(context.Background(), ReportingInput{
+		QueryKind:       QueryDemographic,
+		AccountURNs:     []URN{"urn:li:sponsoredAccount:123"},
+		Level:           LevelAccount,
+		MetricPack:      PackDelivery,
+		Pivots:          []Pivot{PivotMemberCompany, PivotMemberIndustry},
+		DateRange:       &dr,
+		TimeGranularity: GranularityDaily,
+	})
+	if err != nil {
+		t.Fatalf("run reporting: %v", err)
+	}
+
+	req := httpClient.requests[0]
+	if got := req.URL.Query().Get("q"); got != "statistics" {
+		t.Fatalf("unexpected q %q", got)
+	}
+	if got := req.URL.Query().Get("pivots"); got != "List(MEMBER_COMPANY,MEMBER_INDUSTRY)" {
+		t.Fatalf("unexpected pivots %q", got)
+	}
+	if got := req.URL.Query().Get("pivot"); got != "" {
+		t.Fatalf("unexpected single pivot %q", got)
+	}
+	if got := req.URL.Query().Get("fields"); strings.Contains(got, "clicks") {
+		t.Fatalf("explicit fields must not contain clicks: %q", got)
+	}
+}
+
+func TestMetricPackMetricsReflectBasicDefaultMode(t *testing.T) {
+	pack, err := NormalizeMetricPack("basic")
+	if err != nil {
+		t.Fatalf("normalize pack: %v", err)
+	}
+	metrics, err := MetricPackMetrics(pack)
+	if err != nil {
+		t.Fatalf("pack metrics: %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Fatalf("expected basic pack to omit explicit fields, got %v", metrics)
 	}
 }
 
@@ -129,7 +186,7 @@ func TestTruncationWarning(t *testing.T) {
 }
 
 func TestNormalizeMetricPackAndMetrics(t *testing.T) {
-	pack, err := NormalizeMetricPack("basic")
+	pack, err := NormalizeMetricPack("delivery")
 	if err != nil {
 		t.Fatalf("normalize pack: %v", err)
 	}

--- a/internal/linkedin/urn.go
+++ b/internal/linkedin/urn.go
@@ -1,0 +1,129 @@
+package linkedin
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type URN string
+
+func ParseURN(raw string) (URN, string, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", "", errors.New("urn is required")
+	}
+	parts := strings.Split(raw, ":")
+	if len(parts) < 4 || parts[0] != "urn" || parts[1] != "li" {
+		return "", "", "", fmt.Errorf("invalid linkedin urn %q", raw)
+	}
+	return URN(raw), parts[2], strings.Join(parts[3:], ":"), nil
+}
+
+func URNOf(kind string, id string) (URN, error) {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	if kind == "" {
+		return "", errors.New("urn kind is required")
+	}
+	if id == "" {
+		return "", errors.New("urn id is required")
+	}
+	if strings.Contains(id, ":") {
+		return "", fmt.Errorf("urn id must not contain colon: %q", id)
+	}
+	return URN(fmt.Sprintf("urn:li:%s:%s", kind, id)), nil
+}
+
+func SponsoredAccountURN(id string) (URN, error) {
+	return URNOf("sponsoredAccount", id)
+}
+
+func SponsoredCampaignGroupURN(id string) (URN, error) {
+	return URNOf("adCampaignGroup", id)
+}
+
+func SponsoredCampaignURN(id string) (URN, error) {
+	return URNOf("adCampaign", id)
+}
+
+func SponsoredCreativeURN(id string) (URN, error) {
+	return URNOf("creative", id)
+}
+
+func OrganizationURN(id string) (URN, error) {
+	return URNOf("organization", id)
+}
+
+func PersonURN(id string) (URN, error) {
+	return URNOf("person", id)
+}
+
+func NormalizeURN(raw string, kind string) (URN, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("urn is required")
+	}
+	if strings.HasPrefix(raw, "urn:li:") {
+		urn, parsedKind, _, err := ParseURN(raw)
+		if err != nil {
+			return "", err
+		}
+		if kind != "" && parsedKind != kind {
+			return "", fmt.Errorf("unexpected urn kind %q, want %q", parsedKind, kind)
+		}
+		return urn, nil
+	}
+	return URNOf(kind, raw)
+}
+
+func NormalizeSponsoredAccountURN(raw string) (URN, error) {
+	return NormalizeURN(raw, "sponsoredAccount")
+}
+
+func NormalizeSponsoredCampaignGroupURN(raw string) (URN, error) {
+	return NormalizeURN(raw, "adCampaignGroup")
+}
+
+func NormalizeSponsoredCampaignURN(raw string) (URN, error) {
+	return NormalizeURN(raw, "adCampaign")
+}
+
+func NormalizeSponsoredCreativeURN(raw string) (URN, error) {
+	return NormalizeURN(raw, "creative")
+}
+
+func NormalizeOrganizationURN(raw string) (URN, error) {
+	return NormalizeURN(raw, "organization")
+}
+
+func NormalizePersonURN(raw string) (URN, error) {
+	return NormalizeURN(raw, "person")
+}
+
+func BuildURN(kind string, id string) (URN, error) {
+	return URNOf(kind, id)
+}
+
+func ValidateURN(raw string, kind string) error {
+	_, parsedKind, _, err := ParseURN(raw)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(kind) != "" && parsedKind != strings.TrimSpace(kind) {
+		return fmt.Errorf("unexpected urn kind %q, want %q", parsedKind, kind)
+	}
+	return nil
+}
+
+func EncodeURN(raw string) (string, error) {
+	if err := ValidateURN(raw, ""); err != nil {
+		return "", err
+	}
+	return url.PathEscape(strings.TrimSpace(raw)), nil
+}
+
+func (u URN) String() string {
+	return string(u)
+}

--- a/internal/linkedin/urn_test.go
+++ b/internal/linkedin/urn_test.go
@@ -1,0 +1,33 @@
+package linkedin
+
+import "testing"
+
+func TestURNHelpers(t *testing.T) {
+	urn, err := SponsoredAccountURN("123")
+	if err != nil {
+		t.Fatalf("build urn: %v", err)
+	}
+	if urn.String() != "urn:li:sponsoredAccount:123" {
+		t.Fatalf("unexpected urn %q", urn.String())
+	}
+
+	parsed, kind, id, err := ParseURN(urn.String())
+	if err != nil {
+		t.Fatalf("parse urn: %v", err)
+	}
+	if parsed != urn || kind != "sponsoredAccount" || id != "123" {
+		t.Fatalf("unexpected parse result %#v kind=%q id=%q", parsed, kind, id)
+	}
+
+	normalized, err := NormalizeSponsoredAccountURN("urn:li:sponsoredAccount:123")
+	if err != nil {
+		t.Fatalf("normalize urn: %v", err)
+	}
+	if normalized != urn {
+		t.Fatalf("unexpected normalized urn %q", normalized)
+	}
+
+	if _, err := NormalizeSponsoredCampaignURN(""); err == nil {
+		t.Fatal("expected empty campaign urn to fail")
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -21,11 +21,17 @@ type Envelope struct {
 	Command         string     `json:"command"`
 	Timestamp       string     `json:"timestamp"`
 	RequestID       string     `json:"request_id"`
+	Provider        *Provider  `json:"provider,omitempty"`
 	Success         bool       `json:"success"`
 	Data            any        `json:"data,omitempty"`
 	Paging          any        `json:"paging,omitempty"`
 	RateLimit       any        `json:"rate_limit,omitempty"`
 	Error           *ErrorInfo `json:"error,omitempty"`
+}
+
+type Provider struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
 }
 
 type Remediation struct {
@@ -48,6 +54,10 @@ type ErrorInfo struct {
 }
 
 func NewEnvelope(command string, success bool, data any, paging any, rateLimit any, errorInfo *ErrorInfo) (Envelope, error) {
+	return NewEnvelopeWithProvider(command, success, data, paging, rateLimit, errorInfo, nil)
+}
+
+func NewEnvelopeWithProvider(command string, success bool, data any, paging any, rateLimit any, errorInfo *ErrorInfo, provider *Provider) (Envelope, error) {
 	requestID, err := newRequestID()
 	if err != nil {
 		return Envelope{}, err
@@ -57,6 +67,7 @@ func NewEnvelope(command string, success bool, data any, paging any, rateLimit a
 		Command:         command,
 		Timestamp:       time.Now().UTC().Format(time.RFC3339),
 		RequestID:       requestID,
+		Provider:        provider,
 		Success:         success,
 		Data:            data,
 		Paging:          paging,


### PR DESCRIPTION
## Summary
- add LinkedIn as a provider-aware namespace under `meta li` while keeping existing Meta profiles valid under `schema_version: 2`
- extend config, profile resolution, output envelopes, error mapping, and `meta doctor` so Meta and LinkedIn profiles can coexist cleanly
- add `internal/linkedin/...` client, auth, reporting, targeting, creative, campaign, and lead-sync support without a cross-provider rewrite
- fix LinkedIn auth setup to default to the standard 3-legged OAuth endpoint (`/oauth/v2/authorization`) and keep native PKCE available as an explicit `--auth-flow native-pkce` opt-in

## Usage
Existing Meta flows stay unchanged:

```bash
./meta auth setup \
  --profile prod \
  --app-id <APP_ID> \
  --app-secret <APP_SECRET> \
  --mode both \
  --scope-pack solo_smb

./meta --profile prod api get act_<AD_ACCOUNT_ID>/campaigns \
  --fields id,name,status

./meta --profile prod insights run \
  --account-id <AD_ACCOUNT_ID> \
  --date-preset last_7d \
  --level campaign \
  --metric-pack quality
```

New LinkedIn workflows use provider-aware profiles and the `li` namespace:

```bash
./meta li auth setup \
  --profile li-prod \
  --client-id <LINKEDIN_CLIENT_ID> \
  --client-secret <LINKEDIN_CLIENT_SECRET> \
  --auth-flow standard \
  --scopes r_ads,rw_ads,r_ads_reporting

./meta --profile li-prod li account list

./meta --profile li-prod li api get adAccounts \
  --params "q=search"

./meta --profile li-prod li insights run \
  --account-urns urn:li:sponsoredAccount:<ACCOUNT_ID> \
  --since 2026-03-01 \
  --until 2026-03-31 \
  --level CAMPAIGN \
  --metric-pack basic

./meta --profile li-prod li campaign create \
  --account-urn urn:li:sponsoredAccount:<ACCOUNT_ID> \
  --json @campaign.json \
  --confirm-budget-change \
  --confirm-schedule-change

./meta --profile li-prod li lead sync \
  --account-urn urn:li:sponsoredAccount:<ACCOUNT_ID>
```

If your app has LinkedIn native PKCE explicitly enabled, opt in with:

```bash
./meta li auth setup \
  --profile li-prod \
  --client-id <LINKEDIN_CLIENT_ID> \
  --client-secret <LINKEDIN_CLIENT_SECRET> \
  --auth-flow native-pkce \
  --scopes r_ads,rw_ads,r_ads_reporting
```

## Testing
- `go test ./...`
- `go run ./cmd/meta li auth setup --help`
